### PR TITLE
DTSPO-4155 Add excluded resource types to tagging policy

### DIFF
--- a/policies/tagging/policy.json
+++ b/policies/tagging/policy.json
@@ -6,7 +6,13 @@
       "parameters": {
         "excludedResourceTypes": {
           "defaultValue": [
-            "Microsoft.Network/networkWatchers"
+            "Microsoft.Network/networkWatchers",
+            "Microsoft.Web/serverfarms",
+            "Microsoft.Web/sites",
+            "Microsoft.Web/connections",
+            "microsoft.operationalinsights/workspaces",
+            "microsoft.insights/scheduledqueryrules",
+            "microsoft.insights/components"
           ],
           "type": "Array",
           "metadata": {


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/DTSPO-4155


### Change description ###
To exclude resource types which terraform does not offer an option to tag.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
