### PR TITLE
DTSPO-5695 - sbox diag policy scope

### DIFF
--- a/assignments/mg-dts002/assign.diagnostics.json
+++ b/assignments/mg-dts002/assign.diagnostics.json
@@ -7,12 +7,11 @@
       "displayName": "HMCTS Collect Activity Logs",
       "enforcementMode": "Default",
       "nonComplianceMessages": [],
-      "scope": [
-        "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2"
+      "notScopes": [
       ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyDefinitions/HMCTSDiagnostic",
-      "scope": "/providers/Microsoft.Management/managementGroups/dts002"
+      "scope": "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2"
     },
     "location": "uksouth",
     "identity": {


### PR DESCRIPTION
- Initial diagnostic policy commit
- Fix assign json error
- Fix assign json error
- Setting enforcement to doNotEnforce
- Adding managed identity
- Adding managed identity
- Add location to msi
- Moving msi block
- Move msi to assign json
- move msi outside properties block
- remove msi location
- Updating msi location to global
- testing with userassigned
- testing with userassigned
- Add location
- Revert to systemAssigned
- Parameterise event hub name and auth rule
- Fix json
- Fix json
- missing policy rules
- Adding allowed values
- updating auth rule name
- Revert parameter name change
- Missing parameters and naming changes
- Update enforcement mode
- Add diag readme
- Fix scope
