### PR TITLE
DTSPO-5695 - Remove eventHubName

### DIFF
--- a/assignments/mg-dts002/assign.diagnostics.json
+++ b/assignments/mg-dts002/assign.diagnostics.json
@@ -93,6 +93,7 @@
     },
     "location": "uksouth",
     "identity": {
+      "type": "UserAssigned",
       "userAssignedIdentities": {
         "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/soc-diagnostics-mi": {}
       }

--- a/assignments/mg-dts002/assign.diagnostics.json
+++ b/assignments/mg-dts002/assign.diagnostics.json
@@ -31,6 +31,7 @@
         "/subscriptions/0c1744f8-9e63-4742-9c28-c066fd2e6eee",
         "/subscriptions/ff889d39-4517-4135-bbef-95798d1415ad",
         "/subscriptions/a572878d-9725-45d4-a05f-13dd4ac4d09d",
+        "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb",
         "/subscriptions/5709598c-3a1c-4535-8979-f10948b9a031",
         "/subscriptions/a0939257-9c73-48ab-8daa-51cd49ef6c42",
         "/subscriptions/dbd3a97b-580e-4ecb-9ed3-4e86f6f23d25",

--- a/assignments/mg-dts002/assign.diagnostics.json
+++ b/assignments/mg-dts002/assign.diagnostics.json
@@ -31,7 +31,6 @@
         "/subscriptions/0c1744f8-9e63-4742-9c28-c066fd2e6eee",
         "/subscriptions/ff889d39-4517-4135-bbef-95798d1415ad",
         "/subscriptions/a572878d-9725-45d4-a05f-13dd4ac4d09d",
-        "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb",
         "/subscriptions/5709598c-3a1c-4535-8979-f10948b9a031",
         "/subscriptions/a0939257-9c73-48ab-8daa-51cd49ef6c42",
         "/subscriptions/dbd3a97b-580e-4ecb-9ed3-4e86f6f23d25",
@@ -93,10 +92,7 @@
     },
     "location": "uksouth",
     "identity": {
-      "type": "UserAssigned",
-      "userAssignedIdentities": {
-        "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/soc-diagnostics-mi": {}
-      }
+      "type": "SystemAssigned"
     },
     "sku": {
       "name": "A0",

--- a/assignments/mg-dts002/assign.diagnostics.json
+++ b/assignments/mg-dts002/assign.diagnostics.json
@@ -93,7 +93,9 @@
     },
     "location": "uksouth",
     "identity": {
-      "type": "SystemAssigned"
+      "userAssignedIdentities": {
+        "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/soc-diagnostics-mi": {}
+      }
     },
     "sku": {
       "name": "A0",

--- a/policies/diagnostics/policy.json
+++ b/policies/diagnostics/policy.json
@@ -4,18 +4,6 @@
     "policyType": "Custom",
     "mode": "All",
     "parameters": {
-      "eventHubName": {
-        "type": "String",
-        "metadata": {
-          "displayName": "Event Hub Name",
-          "description": null
-        },
-        "allowedValues": [
-          "soc-sbox",
-          "soc-prod"
-        ],
-        "defaultValue": "soc-sbox"
-      },
       "eventHubAuthRule": {
         "type": "String",
         "metadata": {
@@ -23,10 +11,10 @@
           "description": null
         },
         "allowedValues": [
-          "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.EventHub/namespaces/soc-sbox/authorizationRules/soc-eventhub-namespace-sender",
-          "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod/authorizationRules/soc-eventhub-namespace-sender"
+          "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.EventHub/namespaces/soc-sbox-eventhubns/authorizationRules/RootManageSharedAccessKey",
+          "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod-eventhubns/authorizationRules/RootManageSharedAccessKey"
         ],
-        "defaultValue": "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.EventHub/namespaces/soc-sbox/authorizationRules/soc-eventhub-namespace-sender"
+        "defaultValue": "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.EventHub/namespaces/soc-sbox-eventhubns/authorizationRules/RootManageSharedAccessKey"
       }
     },
     "policyRule": {
@@ -42,10 +30,6 @@
           "existenceCondition": {
             "allOf": [
               {
-                "field": "Microsoft.Insights/diagnosticSettings/eventHubName",
-                "equals": "[parameters('eventHubName')]"
-              },
-              {
                 "field": "Microsoft.Insights/diagnosticSettings/eventHubAuthorizationRuleId",
                 "equals": "[parameters('eventHubAuthRule')]"
               }
@@ -60,9 +44,6 @@
                 "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
                 "contentVersion": "1.0.0.0",
                 "parameters": {
-                  "eventHubName": {
-                    "type": "string"
-                  },
                   "eventHubAuthRule": {
                     "type": "string"
                   }
@@ -75,7 +56,6 @@
                     "apiVersion": "2017-05-01-preview",
                     "location": "Global",
                     "properties": {
-                      "eventHubName": "[parameters('eventHubName')]",
                       "eventHubAuthorizationRuleId": "[parameters('eventHubAuthRule')]",
                       "logs": [
                         {
@@ -117,9 +97,6 @@
                 "outputs": {}
               },
               "parameters": {
-                "eventHubName": {
-                  "value": "[parameters('eventHubName')]"
-                },
                 "eventHubAuthRule": {
                   "value": "[parameters('eventHubAuthRule')]"
                 }

--- a/policies/diagnostics/policy.json
+++ b/policies/diagnostics/policy.json
@@ -24,7 +24,7 @@
         },
         "allowedValues": [
           "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.EventHub/namespaces/soc-sbox/authorizationRules/soc-eventhub-namespace-sender",
-          "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod/authorizationRules/soc-eventhub-namespace-sender2"
+          "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod/authorizationRules/soc-eventhub-namespace-sender"
         ],
         "defaultValue": "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.EventHub/namespaces/soc-sbox/authorizationRules/soc-eventhub-namespace-sender"
       }

--- a/policies/diagnostics/policy.json
+++ b/policies/diagnostics/policy.json
@@ -24,7 +24,7 @@
         },
         "allowedValues": [
           "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.EventHub/namespaces/soc-sbox/authorizationRules/soc-eventhub-namespace-sender",
-          "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod/authorizationRules/soc-eventhub-namespace-sender"
+          "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod/authorizationRules/soc-eventhub-namespace-sender2"
         ],
         "defaultValue": "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.EventHub/namespaces/soc-sbox/authorizationRules/soc-eventhub-namespace-sender"
       }

--- a/policies/diagnostics/policy.json
+++ b/policies/diagnostics/policy.json
@@ -23,10 +23,10 @@
           "description": null
         },
         "allowedValues": [
-          "/providers/Microsoft.EventHub/namespaces/soc-sbox/authorizationRules/soc-eventhub-namespace-sender",
-          "/providers/Microsoft.EventHub/namespaces/soc-prod/authorizationRules/soc-eventhub-namespace-sender"
+          "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.EventHub/namespaces/soc-sbox/authorizationRules/soc-eventhub-namespace-sender",
+          "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod/authorizationRules/soc-eventhub-namespace-sender"
         ],
-        "defaultValue": "/providers/Microsoft.EventHub/namespaces/soc-sbox/authorizationRules/soc-eventhub-namespace-sender"
+        "defaultValue": "/subscriptions/2307d175-7e49-434b-9ac2-515529b845f2/resourceGroups/soc-core-infra-sbox-rg/providers/Microsoft.EventHub/namespaces/soc-sbox/authorizationRules/soc-eventhub-namespace-sender"
       }
     },
     "policyRule": {


### PR DESCRIPTION
Authorization rule id may need to be the full resource id including /subscriptions even though documentation suggests /provider will work.

Testing seems to suggest otherwise.
