### PR TITLE
DTSPO-5958 - Adding policy assignment for mgmt group

### DIFF
--- a/assignments/mgmt-groups/mg-dts002/assign.diagnostics.json
+++ b/assignments/mgmt-groups/mg-dts002/assign.diagnostics.json
@@ -1,0 +1,30 @@
+{
+    "properties": {
+      "metadata": {
+        "assignedBy": "PlatOps"
+      },
+      "description": "Forwards all Activity Logs to an Azure Event Hub",
+      "displayName": "HMCTS Collect Activity Logs",
+      "enforcementMode": "Default",
+      "nonComplianceMessages": [],
+      "notScopes": [],
+      "parameters": {
+        "eventHubAuthRule": {
+          "value": "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod-eventhubns/authorizationRules/RootManageSharedAccessKey"
+        }
+      },
+      "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyDefinitions/HMCTSDiagnostic",
+      "scope": "/providers/Microsoft.Management/managementGroups/dts002"
+    },
+    "location": "uksouth",
+    "identity": {
+      "type": "SystemAssigned"
+    },
+    "sku": {
+      "name": "A0",
+      "tier": "Free"
+    },
+    "type": "Microsoft.Authorization/policyAssignments",
+    "id": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyAssignments/HMCTSDiagnosticGlobal",
+    "name": "HMCTSDiagnosticGlobal"
+}


### PR DESCRIPTION
To be merged when SecOps have confirmed that logs are being received by Splunk with the current subscriptions that are set up to forward activity logs to the event hubs.