### PR TITLE
remove scopes that are not matching any non-compliant resources

### DIFF
--- a/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.tagging.json
+++ b/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.tagging.json
@@ -13,9 +13,7 @@
       ],
       "notScopes": [
         "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/cft-sbox-00-aks-node-rg",
-        "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/cft-sbox-01-aks-node-rg",
-        "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/cft-sbox-00-rg",
-        "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/cft-sbox-01-rg"
+        "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/cft-sbox-01-aks-node-rg"
       ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",


### PR DESCRIPTION
the cft-[env]-0[n]-aks-node-rg are covering all the resources that are not being tagged (AKS 'not tagging' bug)

### JIRA link [DTSPO-8039](https://tools.hmcts.net/jira/browse/DTSPO-8039) ###
