### PR TITLE
tagging policy enforcement on nonprod environments

### DIFF
--- a/assignments/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/assign.tagging.json
+++ b/assignments/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/assign.tagging.json
@@ -5,7 +5,7 @@
       },
       "description": "Policy to check required tags",
       "displayName": "HMCTS Tagging - CFT PTL SBOX (DTS-CFTSBOX-INTSVC)",
-      "enforcementMode": "DoNotEnforce",
+      "enforcementMode": "Default",
       "nonComplianceMessages": [
         {
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"

--- a/assignments/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/assign.tagging.json
+++ b/assignments/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/assign.tagging.json
@@ -5,7 +5,7 @@
       },
       "description": "Policy to check required tags",
       "displayName": "HMCTS Tagging - CFT PTL (DTS-CFTPTL-INTSVC)",
-      "enforcementMode": "DoNotEnforce",
+      "enforcementMode": "Default",
       "nonComplianceMessages": [
         {
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"

--- a/assignments/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/assign.tagging.json
+++ b/assignments/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/assign.tagging.json
@@ -5,7 +5,7 @@
       },
       "description": "Policy to check required tags",
       "displayName": "HMCTS Tagging - CFT Demo/AAT (DCD-CNP-DEV)",
-      "enforcementMode": "DoNotEnforce",
+      "enforcementMode": "Default",
       "nonComplianceMessages": [
         {
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"

--- a/assignments/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/assign.tagging.json
+++ b/assignments/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/assign.tagging.json
@@ -5,7 +5,7 @@
       },
       "description": "Policy to check required tags",
       "displayName": "HMCTS Tagging - CFT ITHC",
-      "enforcementMode": "DoNotEnforce",
+      "enforcementMode": "Default",
       "nonComplianceMessages": [
         {
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"

--- a/assignments/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/assign.tagging.json
+++ b/assignments/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/assign.tagging.json
@@ -5,7 +5,7 @@
       },
       "description": "Policy to check required tags",
       "displayName": "HMCTS Tagging - CFT Test (Perftest/ITHC DCD-CNP-QA)",
-      "enforcementMode": "DoNotEnforce",
+      "enforcementMode": "Default",
       "nonComplianceMessages": [
         {
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"

--- a/assignments/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/assign.tagging.json
+++ b/assignments/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/assign.tagging.json
@@ -5,7 +5,7 @@
       },
       "description": "Policy to check required tags",
       "displayName": "HMCTS Tagging - CFT Test (Perftest DCD-CFTAPPS-TEST)",
-      "enforcementMode": "DoNotEnforce",
+      "enforcementMode": "Default",
       "nonComplianceMessages": [
         {
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"

--- a/assignments/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/assign.tagging.json
+++ b/assignments/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/assign.tagging.json
@@ -5,7 +5,7 @@
       },
       "description": "Policy to check required tags",
       "displayName": "HMCTS Tagging - CFT Dev (Preview DCD-CFTAPPS-DEV)",
-      "enforcementMode": "DoNotEnforce",
+      "enforcementMode": "Default",
       "nonComplianceMessages": [
         {
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"

--- a/assignments/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/assign.tagging.json
+++ b/assignments/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/assign.tagging.json
@@ -5,7 +5,7 @@
       },
       "description": "Policy to check required tags",
       "displayName": "HMCTS Tagging - CFT STG (AAT)",
-      "enforcementMode": "DoNotEnforce",
+      "enforcementMode": "Default",
       "nonComplianceMessages": [
         {
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"

--- a/assignments/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/assign.tagging.json
+++ b/assignments/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/assign.tagging.json
@@ -5,7 +5,7 @@
       },
       "description": "Policy to check required tags",
       "displayName": "HMCTS Tagging - CFT Demo (DCD-CFTAPPS-DEMO)",
-      "enforcementMode": "DoNotEnforce",
+      "enforcementMode": "Default",
       "nonComplianceMessages": [
         {
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"


### PR DESCRIPTION
### JIRA link https://tools.hmcts.net/jira/browse/DTSPO-8045 ###

### Change description ###
Changing policy assignment enforcement from `DoNotEnforce` to `Default` which means tagging will now be enforced on create and update of resources on all non prod environments on CFT.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
