### PR TITLE
exclusion for test resource group to create Workbooks

### DIFF
--- a/assignments/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/assign.tagging.json
+++ b/assignments/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/assign.tagging.json
@@ -11,7 +11,9 @@
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"
         }
       ],
-      "notScopes": [],
+      "notScopes": [
+        "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/PlatOpsMonitor_Test"
+      ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",
       "scope": "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783"


### PR DESCRIPTION


### JIRA link N/A ###



### Change description ###
I created a resource group where I can create test workbooks in it. At the moment Azure doesn't allow me to create it under any sandbox Resource group because of tag enforcement, however I get an error when I try adding tags to resources "Kind not supported".

Reason: Workbooks don't allow you to create tags (despite the setting being available, I get an error "Kind not supported").

Workaround is: 
1. Create test resource group in sandbox subscription DCD-CFT-Sandbox (done manually)
2. Add test resource group to noScopes so there is no tagging policy evaluation (this PR).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
