### PR TITLE
Exclude auto-generated azure backup resource group from tagging policy

### DIFF
--- a/assignments/mgmt-groups/mg-dts002/assign.tagging.json
+++ b/assignments/mgmt-groups/mg-dts002/assign.tagging.json
@@ -25,7 +25,8 @@
             "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/ss-prod-01-aks-node-rg",
             "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/ss-prod-00-aks-node-rg",
             "/subscriptions/64b1c6d6-1481-44ad-b620-d8fe26a2c768/resourceGroups/ss-ptlsbox-00-aks-node-rg",
-            "/subscriptions/6c4d2513-a873-41b4-afdd-b05a33206631/resourceGroups/ss-ptl-00-aks-node-rg"
+            "/subscriptions/6c4d2513-a873-41b4-afdd-b05a33206631/resourceGroups/ss-ptl-00-aks-node-rg",
+            "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/AzureBackupRG_uksouth_1/"
         ],
         "parameters": {},
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-9094

### Change description ###

Excludes `AzureBackupRG_uksouth_1` in the from the tagging policy in place so backups generated by a Recovery Services Vault can succeed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
