### PR TITLE
DTSPO-9094 exclude backup resource groups from SDS STG and PROD

### DIFF
--- a/assignments/mgmt-groups/mg-dts002/assign.tagging.json
+++ b/assignments/mgmt-groups/mg-dts002/assign.tagging.json
@@ -25,8 +25,7 @@
             "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/ss-prod-01-aks-node-rg",
             "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/ss-prod-00-aks-node-rg",
             "/subscriptions/64b1c6d6-1481-44ad-b620-d8fe26a2c768/resourceGroups/ss-ptlsbox-00-aks-node-rg",
-            "/subscriptions/6c4d2513-a873-41b4-afdd-b05a33206631/resourceGroups/ss-ptl-00-aks-node-rg",
-            "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/AzureBackupRG_uksouth_1"
+            "/subscriptions/6c4d2513-a873-41b4-afdd-b05a33206631/resourceGroups/ss-ptl-00-aks-node-rg"
         ],
         "parameters": {},
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",

--- a/assignments/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/assign.tagging.json
+++ b/assignments/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/assign.tagging.json
@@ -13,7 +13,8 @@
             "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-00-aks-node-rg",
             "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-01-aks-node-rg",
             "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-00-rg",
-            "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-01-rg"
+            "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-01-rg",
+            "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/AzureBackupRG_uksouth_1"
         ],
         "parameters": {},
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",

--- a/assignments/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/assign.tagging.json
+++ b/assignments/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/assign.tagging.json
@@ -13,7 +13,8 @@
             "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/ss-prod-00-aks-node-rg",
             "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/ss-prod-01-aks-node-rg",
             "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/ss-prod-00-rg",
-            "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/ss-prod-01-rg"
+            "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/ss-prod-01-rg",
+            "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/AzureBackupRG_uksouth_1"
         ],
         "parameters": {},
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",

--- a/assignments/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/assign.tagging.json
+++ b/assignments/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/assign.tagging.json
@@ -13,7 +13,8 @@
             "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-00-aks-node-rg",
             "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-01-aks-node-rg",
             "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-00-rg",
-            "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-01-rg"
+            "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-01-rg",
+            "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/AzureBackupRG_uksouth_1"
         ],
         "parameters": {},
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-9094

### Change description ###

Adds tagging policy exclusions for the resource groups auto-generated by the Azure Recovery Service Vaults in SDS PROD and SDS STG subscriptions.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
