### PR TITLE
Remove the PRE RG in SBox from tagging policy

### DIFF
--- a/assignments/mgmt-groups/mg-dts002/assign.tagging.json
+++ b/assignments/mgmt-groups/mg-dts002/assign.tagging.json
@@ -14,6 +14,7 @@
             "/subscriptions/c68a4bed-4c3d-4956-af51-4ae164c1957c/resourceGroups/ss-demo-01-aks-node-rg",
             "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-01-aks-node-rg",
             "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-00-aks-node-rg",
+            "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/pre-sbox",
             "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-01-aks-node-rg",
             "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-00-aks-node-rg",
             "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/ss-ithc-01-aks-node-rg",


### PR DESCRIPTION
Temp removal of PRE RG pre-sbox from tagging policy as it is failing.
This is to test the use of Azure SQL PaaS with PowerApps.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-744


### Change description ###
Temp change to complete testing of Azure SQL.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
