### PR TITLE
Remove PRE RG in Sbox from tagging policy

### DIFF
--- a/assignments/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/assign.tagging.json
+++ b/assignments/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/assign.tagging.json
@@ -13,7 +13,8 @@
             "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-00-aks-node-rg",
             "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-01-aks-node-rg",
             "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-00-rg",
-            "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-01-rg"
+            "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-01-rg",
+            "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/pre-sbox"
         ],
         "parameters": {},
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/dts002/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",


### PR DESCRIPTION
Temp removal of PRE RG pre-sbox from tagging policy as it is failing.
This is to test the use of Azure SQL PaaS with PowerApps.

JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/S28-744

Change description
Temp change to complete testing of Azure SQL.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
