### PR TITLE
DTSPO-9985 - update README and use mg variable

### DIFF
--- a/.github/workflows/manage-azure-policy.yml
+++ b/.github/workflows/manage-azure-policy.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         set -e
         echo 'subs<<EOF' >> $GITHUB_OUTPUT
-        az account management-group show --name HMCTS --expand -r | jq -r '.children[].children | .. | objects | select( .type == "/subscriptions") | .id' >> $GITHUB_OUTPUT
+        az account management-group show --name ${MANAGEMENT_GROUP} --expand -r | jq -r '.children[].children | .. | objects | select( .type == "/subscriptions") | .id' >> $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: Live - Force compliance check 

--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ You can find more detail on the structure of a `Policy`, `Initiative` or `Assign
 
 ### Workflow permissions
 
-A [custom role](./custom_role.json) was created for the workflow, it's basically a copy of the `Resource Policy Contributor` built in role with a few extra permissions to list subscriptions. 
+A [custom role](./custom_role.json) was created for the workflow, it's basically a copy of the `Resource Policy Contributor` built in role with a few extra permissions to list Management Groups and Subscriptions. 

--- a/README.md
+++ b/README.md
@@ -131,3 +131,8 @@ You can find more detail on the structure of a `Policy`, `Initiative` or `Assign
 - [Definition Structure](https://docs.microsoft.com/en-gb/azure/governance/policy/concepts/definition-structure)
 - [Initiative Structure](https://docs.microsoft.com/en-gb/azure/governance/policy/concepts/initiative-definition-structure)
 - [Assignment structure](https://docs.microsoft.com/en-gb/azure/governance/policy/concepts/assignment-structure)
+
+
+### Workflow permissions
+
+A [custom role](./custom_role.json) was created for the workflow, it's basically a copy of the `Resource Policy Contributor` built in role with a few extra permissions to list subscriptions. 

--- a/custom_role.json
+++ b/custom_role.json
@@ -1,0 +1,28 @@
+{
+  "id": "/providers/Microsoft.Authorization/roleDefinitions/39c041aa-f45a-4dcc-9e8b-39671978c884",
+  "properties": {
+    "roleName": "Azure Policy Manager",
+    "description": "Role for the Azure Policy Manager to manage policies and to be able to list subscriptions so that it can kick off the policy compliance check ",
+    "assignableScopes": [
+      "/providers/Microsoft.Management/managementGroups/HMCTS"
+    ],
+    "permissions": [
+      {
+        "actions": [
+          "Microsoft.Authorization/policyassignments/*",
+          "Microsoft.Authorization/policydefinitions/*",
+          "Microsoft.Authorization/policyexemptions/*",
+          "Microsoft.Authorization/policysetdefinitions/*",
+          "Microsoft.PolicyInsights/*",
+          "Microsoft.Support/*",
+          "Microsoft.Management/register/action",
+          "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/read"
+        ],
+        "notActions": [],
+        "dataActions": [],
+        "notDataActions": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Change description ###
- Added some info on the permissions needed for the github workflow
- Reverting back to using the mg variable instead of a hard-coded value


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
