### PR TITLE
Exclude-Martha-VMs-To-Enable-Backups

### DIFF
--- a/assignments/subscriptions/17390ec1-5a5e-4a20-afb3-38d8d726ae45/assign.tagging.json
+++ b/assignments/subscriptions/17390ec1-5a5e-4a20-afb3-38d8d726ae45/assign.tagging.json
@@ -11,7 +11,9 @@
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"
         }
       ],
-      "notScopes": [],
+      "notScopes": [
+      "/subscriptions/17390ec1-5a5e-4a20-afb3-38d8d726ae45/resourceGroups/martha-rg/providers/Microsoft.RecoveryServices/vaults/martha-rsv-prod/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;martha-rg;martha-vm1-prod/protectedItems/vm;iaasvmcontainerv2;martha-rg;martha-vm2-prod"
+      ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",
       "scope": "/subscriptions/17390ec1-5a5e-4a20-afb3-38d8d726ae45"

--- a/assignments/subscriptions/ae75b9fb-7d34-4112-82ff-64bd3855ce27/assign.tagging.json
+++ b/assignments/subscriptions/ae75b9fb-7d34-4112-82ff-64bd3855ce27/assign.tagging.json
@@ -11,7 +11,9 @@
             "message": "Resource doesn't meet the tagging requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md"
         }
       ],
-      "notScopes": [],
+      "notScopes": [
+        "/subscriptions/ae75b9fb-7d34-4112-82ff-64bd3855ce27/resourceGroups/martha-rg/providers/Microsoft.RecoveryServices/vaults/martha-rsv-stg/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;martha-rg;martha-vm1-stg/protectedItems/vm;iaasvmcontainerv2;martha-rg;martha-vm2-stg"
+      ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",
       "scope": "/subscriptions/ae75b9fb-7d34-4112-82ff-64bd3855ce27"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-11753


### Change description ###
Exclude Martha VM's from tagging policy to enable backups to be created


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
