### PR TITLE
Disable policy on RG for POC

### DIFF
--- a/assignments/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/assign.tagging.json
+++ b/assignments/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/assign.tagging.json
@@ -13,7 +13,8 @@
       ],
       "notScopes": [
         "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/PlatOpsMonitor_Test",
-        "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourcegroups/alliurg2"
+        "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourcegroups/alliurg2",
+        "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/FL_timja-fleet-test_timja-hub_uksouth"  
       ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",


### PR DESCRIPTION
testing out fleet manager but AKS doesn't propagate tags properly