### PR TITLE
Disable tagging policy on timj-db-migrate-rg

### DIFF
--- a/assignments/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/assign.tagging.json
+++ b/assignments/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/assign.tagging.json
@@ -13,7 +13,8 @@
       ],
       "notScopes": [
         "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/cft-ptlsbox-00-aks-node-rg",
-        "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/cft-ptlsbox-01-aks-node-rg"
+        "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/cft-ptlsbox-01-aks-node-rg",
+        "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/timj-db-migrate-rg"  
       ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",


### PR DESCRIPTION
data migration services doesn't work with enforced tags, it tries to create a nic without copying tags