### PR TITLE
Add UK South variation to allowed_regions policy

### DIFF
--- a/policies/allowed_regions/policy.json
+++ b/policies/allowed_regions/policy.json
@@ -7,7 +7,8 @@
       "listOfAllowedLocations": {
         "defaultValue": [
           "uksouth",
-          "global"
+          "global",
+          "UK South"
         ],
         "type": "Array",
         "metadata": {


### PR DESCRIPTION
### Change description ###
Add UK South variation to allowed_regions policy.

Currently a new resource creation failing with error:
`[{"expression":"location","expressionKind":"Field","operator":"In","path":"location","result":"False","targetValue":["uksouth","global"]}]
`

Variable used
```
variable "location" {
  default = "UK South"
}
```
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
