### PR TITLE
fix: exclude B2C tenants from location policy

### DIFF
--- a/policies/allowed_regions/policy.json
+++ b/policies/allowed_regions/policy.json
@@ -16,14 +16,30 @@
           "description": "Permitted HMCTS Regions",
           "strongType": "location"
         }
+      },
+      "excludedResourceTypes": {
+        "defaultValue": [
+          "Microsoft.AzureActiveDirectory/b2cDirectories"
+        ],
+        "type": "Array",
+        "metadata": {
+          "displayName": "Resource Types to exclude",
+          "description": "Resource Types to exclude from compliance results"
+        }
       }
     },
     "policyRule": {
       "if": {
-        "not": {
+        "allOf": [
+          {
+            "field": "type",
+            "notIn": "[parameters('excludedResourceTypes')]"
+          },
+          {
             "field": "location",
-            "in": "[parameters('listOfAllowedLocations')]"
+            "notIn": "[parameters('listOfAllowedLocations')]"
           }
+        ]
       },
       "then": {
         "effect": "deny"


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Exclude B2C tenants from the location policy, as they cannot be placed in UKSouth.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
