### PR TITLE
Bypass policy for LA workspaces

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.tagging.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.tagging.json
@@ -31,7 +31,10 @@
             "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/b2c-darts-sbox",
             "/subscriptions/1fe7db01-9981-4ed3-983c-163dd50ba43a/resourceGroups/DACS-LAB-AVD-RG",
             "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/azure-external-identities-link-rg",
-            "/subscriptions/1fe7db01-9981-4ed3-983c-163dd50ba43a/resourceGroups/NeilM-OpenAI-POC-RG"
+            "/subscriptions/1fe7db01-9981-4ed3-983c-163dd50ba43a/resourceGroups/NeilM-OpenAI-POC-RG",
+            "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourcegroups/oms-automation/providers/microsoft.operationalinsights/workspaces/hmcts-sandbox",
+            "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/oms-automation/providers/microsoft.operationalinsights/workspaces/hmcts-nonprod",
+            "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourcegroups/oms-automation/providers/microsoft.operationalinsights/workspaces/hmcts-prod"
         ],
         "parameters": {},
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",


### PR DESCRIPTION
I need to update a setting and the policy is blocking it, I've verified all tags on hmcts-nonprod and I can't see anything wrong

```json
{
   "tags": {
        "application": "core",
        "businessArea": "Cross-Cutting",
        "builtFrom": "manual",
        "environment": "staging"
    }
}
```