### PR TITLE
Adding wa appinsight resources to exemption list for location.

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_regions.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_regions.json
@@ -198,7 +198,12 @@
         "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/plum-shutter-poc-rg",
         "/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/resourceGroups/cft-platform-shutter-webapp-prod-rg",
         "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/sds-platform-shutter-webapp-prod-rg",
-        "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/dtsse-aat/providers/Microsoft.Dashboard/grafana/dtsse-grafana-aat"
+        "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/dtsse-aat/providers/Microsoft.Dashboard/grafana/dtsse-grafana-aat",
+        "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/wa-prod",
+        "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/wa-aat",
+        "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/wa-demo",
+        "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/wa-ithc",
+        "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/wa-perftest"
       ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSResourceLocationPolicy",


### PR DESCRIPTION



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-2691


### Change description ###

Our jenkins infra build is failing due to a policy violation on location.  It is expecting UK South but we have a location of Wester Europe.  Our apps have all been live for some time so it would be difficult to change this now so I have suggested here we had our resources to the exemption list as others have.  I have added it for all envs since I assume it will fail elsewhere for the same reason.

Let us know if there's an alternative.

This is the build: https://build.platform.hmcts.net/view/WA/job/HMCTS_j_to_z/job/wa-shared-infrastructure/job/ithc/21/console

