### PR TITLE
Exclude Resoure Group from policy for Azure SQL instance

### DIFF
--- a/assignments/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/assign.tagging.json
+++ b/assignments/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/assign.tagging.json
@@ -15,7 +15,8 @@
         "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/cft-ptl-00-aks-node-rg",
         "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/cft-ptl-01-aks-node-rg",
         "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/cft-nonprod-db-migration-rg",
-        "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/cft-prod-db-migration-rg"
+        "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/cft-prod-db-migration-rg",
+        "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/test-database-sbox"
       ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-14926

### Change description ###

This is only for test purpose this will be removed after test. The resources need to be excluded from policy deny effects for normal operation. Resources type Microsoft.Network/networkIntentPolicie. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
