### PR TITLE
fix: excluded SQLMI security alert policies from tagging and expiresAfter policies

### DIFF
--- a/policies/expires-after-tagging/policy.json
+++ b/policies/expires-after-tagging/policy.json
@@ -1,67 +1,67 @@
 {
-    "properties": {
-      "displayName": "HMCTS Expires After Tagging",
-      "policyType": "Custom",
-      "mode": "Indexed",
-
-      "parameters": {
-        "excludedResourceTypes": {
-          "defaultValue": [
-            "Microsoft.Network/networkWatchers",
-            "Microsoft.RecoveryServices/vaults",
-            "Microsoft.Compute/snapshots",
-            "microsoft.alertsmanagement/smartdetectoralertrules",
-            "microsoft.insights/actiongroups",
-            "Microsoft.Insights/activityLogAlerts",
-            "microsoft.operationsmanagement/solutions",
-            "Microsoft.ContainerRegistry/registries/tasks",
-            "Microsoft.Network/dnsResolvers/inboundEndpoints",
-            "Microsoft.Network/dnsResolvers/outboundEndpoints",
-            "Microsoft.Network/networkWatchers/flowLogs",
-            "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-            "Microsoft.Compute/restorePointCollections",
-            "microsoft.network/vpnserverconfigurations",
-            "microsoft.network/virtualhubs",
-            "microsoft.network/virtualwans"
-          ],
-          "type": "Array",
-          "metadata": {
-            "displayName": "Resource Types to exclude",
-            "description": "Resource Types to exclude from compliance results"
-          }
-        },
-        "RequiredTag": {
-          "defaultValue": "expiresAfter",
-          "type": "String",
-          "metadata": {
-            "displayName": "Required Tag Name",
-            "description": "Required expiresAfter tag on resource"
-          }
+  "properties": {
+    "displayName": "HMCTS Expires After Tagging",
+    "policyType": "Custom",
+    "mode": "Indexed",
+    "parameters": {
+      "excludedResourceTypes": {
+        "defaultValue": [
+          "Microsoft.Network/networkWatchers",
+          "Microsoft.RecoveryServices/vaults",
+          "Microsoft.Compute/snapshots",
+          "microsoft.alertsmanagement/smartdetectoralertrules",
+          "microsoft.insights/actiongroups",
+          "Microsoft.Insights/activityLogAlerts",
+          "microsoft.operationsmanagement/solutions",
+          "Microsoft.ContainerRegistry/registries/tasks",
+          "Microsoft.Network/dnsResolvers/inboundEndpoints",
+          "Microsoft.Network/dnsResolvers/outboundEndpoints",
+          "Microsoft.Network/networkWatchers/flowLogs",
+          "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+          "Microsoft.Compute/restorePointCollections",
+          "microsoft.network/vpnserverconfigurations",
+          "microsoft.network/virtualhubs",
+          "microsoft.network/virtualwans",
+          "Microsoft.Sql/managedInstances/securityAlertPolicies"
+        ],
+        "type": "Array",
+        "metadata": {
+          "displayName": "Resource Types to exclude",
+          "description": "Resource Types to exclude from compliance results"
         }
       },
-      "policyRule": {
-        "if": {
-          "allOf": [
-            {
-              "field": "type",
-              "notIn": "[parameters('excludedResourceTypes')]"
-            },
-            {
-              "anyOf": [
-                {
-                  "field": "[concat('tags[', parameters('RequiredTag'), ']')]",
-                  "notMatch": "####-##-##"
-                }
-              ]
-            }
-          ]
-        },
-        "then": {
-          "effect": "deny"
+      "RequiredTag": {
+        "defaultValue": "expiresAfter",
+        "type": "String",
+        "metadata": {
+          "displayName": "Required Tag Name",
+          "description": "Required expiresAfter tag on resource"
         }
       }
     },
-    "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/ExpiresAfterTagging",
-    "type": "Microsoft.Authorization/policyDefinitions",
-    "name": "ExpiresAfterTagging"
-  }
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "notIn": "[parameters('excludedResourceTypes')]"
+          },
+          {
+            "anyOf": [
+              {
+                "field": "[concat('tags[', parameters('RequiredTag'), ']')]",
+                "notMatch": "####-##-##"
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "deny"
+      }
+    }
+  },
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/ExpiresAfterTagging",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "name": "ExpiresAfterTagging"
+}

--- a/policies/tagging/policy.json
+++ b/policies/tagging/policy.json
@@ -1,112 +1,113 @@
 {
-    "properties": {
-      "displayName": "HMCTS Tagging",
-      "policyType": "Custom",
-      "mode": "Indexed",
-      "parameters": {
-        "excludedResourceTypes": {
-          "defaultValue": [
-            "Microsoft.Network/networkWatchers",
-            "Microsoft.RecoveryServices/vaults",
-            "Microsoft.Compute/snapshots",
-            "microsoft.alertsmanagement/smartdetectoralertrules",
-            "microsoft.insights/actiongroups",
-            "Microsoft.Insights/activityLogAlerts",
-            "microsoft.operationsmanagement/solutions",
-            "Microsoft.ContainerRegistry/registries/tasks",
-            "Microsoft.Network/dnsResolvers/inboundEndpoints",
-            "Microsoft.Network/dnsResolvers/outboundEndpoints",
-            "Microsoft.Network/networkWatchers/flowLogs",
-            "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-            "Microsoft.Compute/restorePointCollections",
-            "Microsoft.Compute/virtualMachines/extensions"
-          ],
-          "type": "Array",
-          "metadata": {
-            "displayName": "Resource Types to exclude",
-            "description": "Resource Types to exclude from compliance results"
-          }
-        },
-        "allowedEnvironmentNames": {
-          "defaultValue": [
-            "sandbox",
-            "development",
-            "testing",
-            "demo",
-            "ITHC",
-            "staging",
-            "production",
-            "preview"
-          ],
-          "type": "Array",
-          "metadata": {
-            "displayName": "Allowed environment Names",
-            "description": "Allowed environment names such as production or staging"
-          }
-        },
-        "allowedBusinessAreaNames": {
-          "defaultValue": [
-            "CFT",
-            "crime",
-            "Cross-Cutting"
-          ],
-          "type": "Array",
-          "metadata": {
-            "displayName": "Allowed businessArea names",
-            "description": "Allowed businessArea names such as CFT or crime"
-          }
-        },
-        "RequiredTags": {
-          "type": "Array",
-          "defaultValue": [
-            "environment",
-            "application",
-            "businessArea",
-            "builtFrom"
-          ],
-          "metadata": {
-            "displayName": "Required Tags",
-            "description": "The list of Required tags for resources."
-          }
+  "properties": {
+    "displayName": "HMCTS Tagging",
+    "policyType": "Custom",
+    "mode": "Indexed",
+    "parameters": {
+      "excludedResourceTypes": {
+        "defaultValue": [
+          "Microsoft.Network/networkWatchers",
+          "Microsoft.RecoveryServices/vaults",
+          "Microsoft.Compute/snapshots",
+          "microsoft.alertsmanagement/smartdetectoralertrules",
+          "microsoft.insights/actiongroups",
+          "Microsoft.Insights/activityLogAlerts",
+          "microsoft.operationsmanagement/solutions",
+          "Microsoft.ContainerRegistry/registries/tasks",
+          "Microsoft.Network/dnsResolvers/inboundEndpoints",
+          "Microsoft.Network/dnsResolvers/outboundEndpoints",
+          "Microsoft.Network/networkWatchers/flowLogs",
+          "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+          "Microsoft.Compute/restorePointCollections",
+          "Microsoft.Compute/virtualMachines/extensions",
+          "Microsoft.Sql/managedInstances/securityAlertPolicies"
+        ],
+        "type": "Array",
+        "metadata": {
+          "displayName": "Resource Types to exclude",
+          "description": "Resource Types to exclude from compliance results"
         }
       },
-      "policyRule": {
-        "if": {
-          "allOf": [
-            {
-              "field": "type",
-              "notIn": "[parameters('excludedResourceTypes')]"
-            },
-            {
-              "anyOf": [
-                {
-                  "count": {
-                    "value": "[parameters('RequiredTags')]",
-                    "where": {
-                      "field": "tags",
-                      "notContainsKey": "[current()]"
-                    }
-                  },
-                  "greater": 0
-                },
-                {
-                  "field": "tags['environment']",
-                  "notIn": "[parameters('allowedEnvironmentNames')]"
-                },
-                {
-                  "field": "tags['businessArea']",
-                  "notIn": "[parameters('allowedBusinessAreaNames')]"
-                }
-              ]
-            }
-          ]
-        },
-        "then": {
-          "effect": "deny"
+      "allowedEnvironmentNames": {
+        "defaultValue": [
+          "sandbox",
+          "development",
+          "testing",
+          "demo",
+          "ITHC",
+          "staging",
+          "production",
+          "preview"
+        ],
+        "type": "Array",
+        "metadata": {
+          "displayName": "Allowed environment Names",
+          "description": "Allowed environment names such as production or staging"
+        }
+      },
+      "allowedBusinessAreaNames": {
+        "defaultValue": [
+          "CFT",
+          "crime",
+          "Cross-Cutting"
+        ],
+        "type": "Array",
+        "metadata": {
+          "displayName": "Allowed businessArea names",
+          "description": "Allowed businessArea names such as CFT or crime"
+        }
+      },
+      "RequiredTags": {
+        "type": "Array",
+        "defaultValue": [
+          "environment",
+          "application",
+          "businessArea",
+          "builtFrom"
+        ],
+        "metadata": {
+          "displayName": "Required Tags",
+          "description": "The list of Required tags for resources."
         }
       }
     },
-    "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",
-    "type": "Microsoft.Authorization/policyDefinitions",
-    "name": "HMCTSTagging"
-  }
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "notIn": "[parameters('excludedResourceTypes')]"
+          },
+          {
+            "anyOf": [
+              {
+                "count": {
+                  "value": "[parameters('RequiredTags')]",
+                  "where": {
+                    "field": "tags",
+                    "notContainsKey": "[current()]"
+                  }
+                },
+                "greater": 0
+              },
+              {
+                "field": "tags['environment']",
+                "notIn": "[parameters('allowedEnvironmentNames')]"
+              },
+              {
+                "field": "tags['businessArea']",
+                "notIn": "[parameters('allowedBusinessAreaNames')]"
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "deny"
+      }
+    }
+  },
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "name": "HMCTSTagging"
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14926


### Change description ###
Exclude SQL MI Security Alter Policies from tagging and expires after policies, these resources can't be tagged and are deployed automatically when you provision as SQL MI.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
