### PR TITLE
DTSPO-15235 Exclude VM extensions from tagging requirements

### DIFF
--- a/policies/tagging/policy.json
+++ b/policies/tagging/policy.json
@@ -13,6 +13,7 @@
           "microsoft.insights/actiongroups",
           "Microsoft.Insights/activityLogAlerts",
           "microsoft.operationsmanagement/solutions",
+          "Microsoft.Compute/virtualMachines/extensions",
           "Microsoft.ContainerRegistry/registries/tasks",
           "Microsoft.Network/dnsResolvers/inboundEndpoints",
           "Microsoft.Network/dnsResolvers/outboundEndpoints",


### PR DESCRIPTION
Portal, CLI and powershell don't support tagging them.

Needs to be done via REST API or ARM

Lets remove the requirement