### PR TITLE
excluded fw policies from tagging and expireafter

### DIFF
--- a/policies/expires-after-tagging/policy.json
+++ b/policies/expires-after-tagging/policy.json
@@ -29,7 +29,8 @@
           "Microsoft.Sql/virtualClusters",
           "Microsoft.Network/networkIntentPolicies",
           "Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions",
-          "Microsoft.Network/serviceEndpointPolicies"
+          "Microsoft.Network/serviceEndpointPolicies",
+          "Microsoft.Network/FrontDoorWebApplicationFirewallPolicies"
         ],
         "type": "Array",
         "metadata": {

--- a/policies/tagging/policy.json
+++ b/policies/tagging/policy.json
@@ -27,7 +27,8 @@
           "Microsoft.Sql/virtualClusters",
           "Microsoft.Network/networkIntentPolicies",
           "Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions",
-          "Microsoft.Network/serviceEndpointPolicies"
+          "Microsoft.Network/serviceEndpointPolicies",
+          "Microsoft.Network/FrontDoorWebApplicationFirewallPolicies"
         ],
         "type": "Array",
         "metadata": {


### PR DESCRIPTION




### Change description ###

When trying to create new frontdoor using portal or using powershell script, there is no way we can input tags for the WAF policies hence excluded them

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
