### PR TITLE
fix policy assignment name length must not exceed

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.copy.rg.required.tags.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.copy.rg.required.tags.json
@@ -20,6 +20,6 @@
       "tier": "Free"
     },
     "type": "Microsoft.Authorization/policyAssignments",
-    "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyResourceGroupTags",
-    "name": "HMCTSCopyResourceGroupTags"
+    "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyRGTags",
+    "name": "HMCTSCopyRGTags"
 }

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.copy.expireafter.tag.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.copy.expireafter.tag.json
@@ -20,6 +20,6 @@
       "tier": "Free"
     },
     "type": "Microsoft.Authorization/policyAssignments",
-    "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyResourceGroupexpiresafterTag_CFT-Sbox",
-    "name": "HMCTSCopyResourceGroupexpiresafterTag_CFT-Sbox"
+    "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyExp-CFT-Sbox",
+    "name": "HMCTSCopyExp-CFT-Sbox"
 }

--- a/assignments/mgmt-groups/mg-platform-sandbox/assign.copy.expireafter.tag.json
+++ b/assignments/mgmt-groups/mg-platform-sandbox/assign.copy.expireafter.tag.json
@@ -20,6 +20,6 @@
       "tier": "Free"
     },
     "type": "Microsoft.Authorization/policyAssignments",
-    "id": "/providers/Microsoft.Management/managementGroups/Platform-Sandbox/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyResourceGroupexpiresafterTag_Plat-Sbox",
-    "name": "HMCTSCopyResourceGroupexpiresafterTag_Plat-Sbox"
+    "id": "/providers/Microsoft.Management/managementGroups/Platform-Sandbox/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyExp-Plat-Sbox",
+    "name": "HMCTSCopyExp-Plat-Sbox"
 }

--- a/assignments/mgmt-groups/mg-sds-sandbox/assign.copy.expireafter.tag.json
+++ b/assignments/mgmt-groups/mg-sds-sandbox/assign.copy.expireafter.tag.json
@@ -20,6 +20,6 @@
       "tier": "Free"
     },
     "type": "Microsoft.Authorization/policyAssignments",
-    "id": "/providers/Microsoft.Management/managementGroups/SDS-Sandbox/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyResourceGroupexpiresafterTag_SDS-Sbox",
-    "name": "HMCTSCopyResourceGroupexpiresafterTag_SDS-Sbox"
+    "id": "/providers/Microsoft.Management/managementGroups/SDS-Sandbox/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyExp-SDS-Sbox",
+    "name": "HMCTSCopyExp-SDS-Sbox"
 }

--- a/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.copy.expireafter.tag.sandbox.json
+++ b/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.copy.expireafter.tag.sandbox.json
@@ -20,6 +20,6 @@
       "tier": "Free"
     },
     "type": "Microsoft.Authorization/policyAssignments",
-    "id": "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyResourceGroupexpiresafterTag",
-    "name": "HMCTSCopyResourceGroupexpiresafterTag_DCD-CFTAPPS-SBOX"
+    "id": "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyExp-CFT-SBOX",
+    "name": "HMCTSCopyExp-CFT-SBOX"
 }

--- a/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.copy.expireafter.tag.sandbox.json
+++ b/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.copy.expireafter.tag.sandbox.json
@@ -20,6 +20,6 @@
       "tier": "Free"
     },
     "type": "Microsoft.Authorization/policyAssignments",
-    "id": "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyExp-CFT-SBOX",
-    "name": "HMCTSCopyExp-CFT-SBOX"
+    "id": "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/providers/Microsoft.Authorization/policyAssignments/HMCTSCopyExp-sub-SBOX",
+    "name": "HMCTSCopyExp-sub-SBOX"
 }


### PR DESCRIPTION
### Change description ###

After applying new copy tags policy, it failed to rollout because assignment name was too long. 

https://github.com/hmcts/azure-policy/actions/runs/6743864187/job/18332595163
