### PR TITLE
Removing the VM SKU policy from sec ops groups so they can be deleted

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_vm_sku.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_vm_sku.json
@@ -12,6 +12,9 @@
       }
     ],
     "notScopes": [
+      "/subscriptions/3d84f717-22a0-4f4e-aac7-5ff8f4ee0a90/resourceGroups/PRP-PENTEST-01",
+      "/subscriptions/28d33a47-7c14-456d-9a40-ce9c9b5a3937/resourceGroups/RG-MLV-PENTEST-01",
+      "/subscriptions/55c2f45e-1381-4b17-9bd0-f85215b8bb4f/resourceGroups/RG-PRD-PENTEST-01",
       "/subscriptions/66cfcc0b-d764-4c07-bbeb-0a74101dbcf3/resourceGroups/RG-MGT-VNET-01",
       "/subscriptions/66cfcc0b-d764-4c07-bbeb-0a74101dbcf3/resourceGroups/RG-MGT-DEV-INFRA-01",
       "/subscriptions/66cfcc0b-d764-4c07-bbeb-0a74101dbcf3/resourceGroups/RG-MGT-OPS-INFRA-01",


### PR DESCRIPTION
### Jira link (if applicable)

n/a

### Change description ###
Deleting some old SecOps VM's and hit an issue with the SKU VM Policy. Need to remove the scope so these VM's can be removed

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
