### PR TITLE
DTSPO-15909 - allow app insight to all region

### DIFF
--- a/policies/allowed_regions/policy.json
+++ b/policies/allowed_regions/policy.json
@@ -21,7 +21,8 @@
         "defaultValue": [
           "Microsoft.AzureActiveDirectory/b2cDirectories",
           "Microsoft.Cdn/profiles",
-          "Microsoft.Cdn/profiles/endpoints"
+          "Microsoft.Cdn/profiles/endpoints",
+          "Microsoft.Insights/components"
         ],
         "type": "Array",
         "metadata": {


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###

While migrating App insights, we have noticed quite a few app insights are deployed on West Europe and region policy blocking us to update it so adding app insight as exception to see if we can avoid this block.

