### PR TITLE
Update policy definition to only apply to data catalogue nonprod envi…

### DIFF
--- a/policies/purview/policy.json
+++ b/policies/purview/policy.json
@@ -92,11 +92,11 @@
               "anyOf": [
                 {
                   "field": "name",
-                  "contains": "dc-purview"
+                  "contains": "dc-purview-dev"
                 },
                 {
                   "field": "name",
-                  "contains": "dc-mspurview"
+                  "contains": "dc-mspurview-test"
                 }
               ]
             }


### PR DESCRIPTION
…ronments

### Jira link (if applicable)
DC-206-purviewNonprodOnly


### Change description ###
Update policy definition to only apply to data catalogue nonprod environments, due to a production release of the catalogue on 28th Feb

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
