### PR TITLE
DTSPO-16273 Revert a change that AppInsight component added to excludedResourceTypes

### DIFF
--- a/policies/allowed_regions/policy.json
+++ b/policies/allowed_regions/policy.json
@@ -22,7 +22,6 @@
           "Microsoft.AzureActiveDirectory/b2cDirectories",
           "Microsoft.Cdn/profiles",
           "Microsoft.Cdn/profiles/endpoints",
-          "Microsoft.Insights/components",
           "Microsoft.Cdn/profiles",
           "microsoft.insights/scheduledqueryrules"
         ],


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16273

### Change description ###
Revert a change that AppInsight component added to excludedResourceTypes. The change was made in this PR
https://github.com/hmcts/azure-policy/pull/304

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
