### PR TITLE
feat: added exclusion for darts-migration-prod-rg

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_vm_sku.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_vm_sku.json
@@ -189,7 +189,8 @@
       "/subscriptions/4bb049c8-33f3-4860-91b4-9ee45375cc18/resourceGroups/VH-WOWZA-PROD",
       "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/libragob-test-rg",
       "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/libragob-stg-rg",
-      "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/libragob-prod-rg"
+      "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/libragob-prod-rg",
+      "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/darts-migration-prod-rg"
     ],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSVmSkuSize",


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17130


### Change description ###
Justification:
```
Hi Alex,
 
Are we able to please increase the RAM allocation on prddartsmigora01 to 64GB, but leave the CPU count at 4.

Reason being, we need to increase resource available to help with the performance of the Oracle DB on that server, without increasing the CPU core count which is how the Oracle licencing is determined.
We can’t use the current PlatOps approved templates as this would result in an increased CPU count, and that will incur significant licencing cost we don’t have approved.
 
Thanks,
 
Sean Bulley
Technical Architect
```

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
