### PR TITLE
DTSPO-16138 - Temporary exclude for tagging cvp sbox rg

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.tagging.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.tagging.json
@@ -41,7 +41,8 @@
             "/subscriptions/c68a4bed-4c3d-4956-af51-4ae164c1957c/resourceGroups/help-with-fees-demo",
             "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/help-with-fees-prod",
             "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/lz-stg-rg",
-            "/subscriptions/1fe7db01-9981-4ed3-983c-163dd50ba43a/resourceGroups/rg-platops-chatbot"
+            "/subscriptions/1fe7db01-9981-4ed3-983c-163dd50ba43a/resourceGroups/rg-platops-chatbot",
+            "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/cvp-sharedinfra-sbox"
         ],
         "parameters": {},
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",

--- a/assignments/mgmt-groups/mg-sds-sandbox/assign.expiresaftertag.json
+++ b/assignments/mgmt-groups/mg-sds-sandbox/assign.expiresaftertag.json
@@ -21,7 +21,8 @@
       "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ingest00-logging-sbox",
       "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/oz-rg",
       "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/rsi-nd-rg", 
-      "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ingest00-metadata-sbox"
+      "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ingest00-metadata-sbox",
+      "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/cvp-sharedinfra-sbox"
     ],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/ExpiresAfterTagging",


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16138

### Change description ###
Temporarily exclude resource group from tagging policy so deleted keyvault can be restored and pipeline errors fixed
Pipeline errors need fixed so hub-terraform-infra pipeline is unblocked. Currently failing due to missing dependency

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
