### PR TITLE
DTSPO-16138 - Temporary exclude for tagging cvp sbox rg

### DIFF
--- a/assignments/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/assign.tagging.json
+++ b/assignments/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/assign.tagging.json
@@ -22,7 +22,8 @@
             "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/lz-sbox-rg",
             "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ingest-mgmt-rg-sbox",
             "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ingest00-logging-sbox",
-            "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ingest00-metadata-sbox"
+            "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ingest00-metadata-sbox",
+            "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/cvp-sharedinfra-sbox"
         ],
         "parameters": {},
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSTagging",


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16138

### Change description ###
Temporarily exclude resource group from tagging policy so deleted keyvault can be restored and pipeline errors fixed
Pipeline errors need fixed so hub-terraform-infra pipeline is unblocked. Currently failing due to missing dependency

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
