### PR TITLE
Exclude AI PoC from location policy

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_regions.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_regions.json
@@ -195,6 +195,7 @@
         "/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/resourceGroups/shutter-app-prod-rg",
         "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/rd-aks-preview",
         "/subscriptions/1fe7db01-9981-4ed3-983c-163dd50ba43a/resourceGroups/NeilM-OpenAI-POC-RG",
+        "/subscriptions/1fe7db01-9981-4ed3-983c-163dd50ba43a/resourceGroups/timj-ai-poc-rg",
         "/subscriptions/1fe7db01-9981-4ed3-983c-163dd50ba43a/resourceGroups/dasi-ai",
         "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/bluesquadpoc",
         "/subscriptions/64b1c6d6-1481-44ad-b620-d8fe26a2c768/resourceGroups/bluesquadpoc",


### PR DESCRIPTION
The serverless models are only available in the US

Cheaper to not have to provision resources at least in PoC