### PR TITLE
DTSPO-17544 - Exclude test rg from allowed regions policy

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_regions.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_regions.json
@@ -234,7 +234,8 @@
         "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/bar-ithc-rg",
         "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/bar-perftest-rg",
         "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/bar-prod-rg",
-        "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/cft-sbox-apim-testmigrate-rg"
+        "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/cft-sbox-apim-testmigrate-rg",
+        "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/dtspo-17544"
       ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSResourceLocationPolicy",


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17544

### Change description ###
Add exclusion to allowed regions policy so I can deploy a test APIM instance to my test resource group
This is to test if an APIM instance more closely located to Slack's datacentres will help the incident bot
Will be reverted after testing

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
