### PR TITLE
Adding new resource type to tagging exemption: Microsoft.Security/automations

### DIFF
--- a/policies/tagging/policy.json
+++ b/policies/tagging/policy.json
@@ -30,7 +30,8 @@
           "Microsoft.Network/serviceEndpointPolicies",
           "Microsoft.Network/FrontDoorWebApplicationFirewallPolicies",
           "Microsoft.Network/FrontDoors",
-          "Microsoft.Cdn/profiles"
+          "Microsoft.Cdn/profiles",
+          "Microsoft.Security/automations"
         ],
         "type": "Array",
         "metadata": {


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-19515

### Change description

Tagging policy blocks deployment of eventHub security resource for this story.