### PR TITLE
Update policy to add existence condition

### DIFF
--- a/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.keyvault_diagnostics_moj.json
+++ b/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.keyvault_diagnostics_moj.json
@@ -16,7 +16,7 @@
                 "value": "azure-resource-events"
             },
             "eventHubAuthRule": {
-                "value": "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-xsiam-eventhubs-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod-xsiam-eventhubns/eventhubs/azure-resource-events/authorizationrules/DiagnosticSharedAccessKey"
+                "value": "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-xsiam-eventhubs-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod-xsiam-eventhubns/authorizationrules/soc-xsiam-eventhub-namespace-sender"
             }
         },
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSKeyVault",

--- a/policies/keyvault/policy.json
+++ b/policies/keyvault/policy.json
@@ -119,6 +119,10 @@
                   }
                 },
                 "greaterOrEquals": 1
+              },
+              {
+                "field": "Microsoft.Insights/diagnosticSettings/eventHubAuthorizationRuleId",
+                "equals": "[parameters('eventHubAuthRule')]"
               }
             ]
           },


### PR DESCRIPTION
Trying to get parameter name changes to take effect **without** updating profileNames and making more cleanup
This has been tested in sbox and correctly performs a new compliance check and remediation of resources to get the new eventhub name