### PR TITLE
DTSPO-22116 - Adding exception for atlassin nonprod RG

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_disk_sku.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_disk_sku.json
@@ -22,7 +22,8 @@
       "/subscriptions/17390ec1-5a5e-4a20-afb3-38d8d726ae45/resourceGroups/PCMAN-RG",
       "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-splunk-prod-rg",
       "/subscriptions/79898897-729c-41a0-a5ca-53c764839d95/resourceGroups/RG-PRD-ATL-INT-01",
-      "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/juror-er-migration-prod"
+      "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/juror-er-migration-prod",
+      "/subscriptions/b7d2bd5f-b744-4acc-9c73-e068cec2e8d8/resourceGroups/atlassian-nonprod-rg"
     ],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSDiskSkuSize",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_vm_sku.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_vm_sku.json
@@ -195,7 +195,8 @@
       "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/libragob-test-rg",
       "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/libragob-stg-rg",
       "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/libragob-prod-rg",
-      "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/darts-migration-prod-rg"
+      "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/darts-migration-prod-rg",
+      "/subscriptions/b7d2bd5f-b744-4acc-9c73-e068cec2e8d8/resourceGroups/atlassian-nonprod-rg"
     ],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSVmSkuSize",


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-22116

### Change description

Added exception for Atlassian nonprod resource group so that we can restore the VMs as the VMs are different sizes.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
