### PR TITLE
DTSPO-23913 - adding exception for atlassian prod build

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_disk_sku.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_disk_sku.json
@@ -24,6 +24,7 @@
       "/subscriptions/79898897-729c-41a0-a5ca-53c764839d95/resourceGroups/RG-PRD-ATL-INT-01",
       "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/juror-er-migration-prod",
       "/subscriptions/b7d2bd5f-b744-4acc-9c73-e068cec2e8d8/resourceGroups/atlassian-nonprod-rg",
+      "/subscriptions/79898897-729c-41a0-a5ca-53c764839d95/resourceGroups/atlassian-prod-rg",
       "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/darts-migration-stg-rg",
       "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/darts-migration-prod-rg"
     ],

--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_vm_sku.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_vm_sku.json
@@ -196,7 +196,8 @@
       "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/libragob-stg-rg",
       "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/libragob-prod-rg",
       "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/darts-migration-prod-rg",
-      "/subscriptions/b7d2bd5f-b744-4acc-9c73-e068cec2e8d8/resourceGroups/atlassian-nonprod-rg"
+      "/subscriptions/b7d2bd5f-b744-4acc-9c73-e068cec2e8d8/resourceGroups/atlassian-nonprod-rg",
+      "/subscriptions/79898897-729c-41a0-a5ca-53c764839d95/resourceGroups/atlassian-prod-rg"
     ],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSVmSkuSize",


### PR DESCRIPTION
Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23913

Change description
Added exception for Atlassian prod resource group so that we can restore the VMs as the VMs are different sizes.

Checklist
[x] commit messages are meaningful and follow good commit message guidelines
[ ] README and other documentation has been updated / added (if needed)
[ ] tests have been updated / new tests has been added (if needed)
[ ] Does this PR introduce a breaking change