### PR TITLE
Exclude resource graph queries from tagging

### DIFF
--- a/policies/tagging/policy.json
+++ b/policies/tagging/policy.json
@@ -31,7 +31,8 @@
           "Microsoft.Network/FrontDoorWebApplicationFirewallPolicies",
           "Microsoft.Network/FrontDoors",
           "Microsoft.Cdn/profiles",
-          "Microsoft.Security/automations"
+          "Microsoft.Security/automations",
+          "Microsoft.ResourceGraph/queries"
         ],
         "type": "Array",
         "metadata": {


### PR DESCRIPTION
### Jira link

N/A

### Change description

Excluding resource graph queries from tagging. These can be useful to share a list of Azure resources in a Jira ticket. They don't incur a cost as far as I know.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
