### PR TITLE
feat: Add NSG diagnostics policy assignment for GLIMR development

### DIFF
--- a/assignments/subscriptions/d24c931e-2e6d-4508-8583-85ac42715580/assign.nsg_diagnostics_glimr-rg-dev.json
+++ b/assignments/subscriptions/d24c931e-2e6d-4508-8583-85ac42715580/assign.nsg_diagnostics_glimr-rg-dev.json
@@ -1,0 +1,45 @@
+{
+    "properties": {
+        "metadata": {
+            "assignedBy": "https://github.com/hmcts/azure-policy"
+        },
+        "description": "Forwards Network Security Group Logs from glimr-rg-dev resource group to Azure Event Hub - MOJ",
+        "displayName": "HMCTS Collect NSG Logs - glimr-rg-dev (GLIMR Dev Subscription)",
+        "enforcementMode": "Default",
+        "nonComplianceMessages": [],
+        "notScopes": [],
+        "parameters": {
+            "profileName": {
+                "value": "NSG-SOC-Prod-GLIMR"
+            },
+            "eventHubName": {
+                "value": "network-security-group"
+            },
+            "eventHubAuthRule": {
+                "value": "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-xsiam-eventhubs-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod-xsiam-eventhubns/authorizationrules/soc-xsiam-eventhub-namespace-sender"
+            },
+            "eventHubLocation": {
+                "value": "uksouth"
+            },
+            "logsEnabled": {
+                "value": "True"
+            }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSNSGDiagnostic",
+        "scope": "/subscriptions/d24c931e-2e6d-4508-8583-85ac42715580/resourceGroups/glimr-rg-dev"
+    },
+    "location": "uksouth",
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/soc-prod-eventhub-azure-policy": {}
+        }
+    },
+    "sku": {
+        "name": "A0",
+        "tier": "Free"
+    },
+    "type": "Microsoft.Authorization/policyAssignments",
+    "id": "/subscriptions/d24c931e-2e6d-4508-8583-85ac42715580/resourceGroups/glimr-rg-dev/providers/Microsoft.Authorization/policyAssignments/HMCTSNSGDiagnostic_glimr-rg-dev",
+    "name": "HMCTSNSGDiagnostic_glimr-rg-dev"
+}


### PR DESCRIPTION
## Summary
This PR adds a new policy assignment for the NSG diagnostics policy (`HMCTSNSGDiagnostic`) to support the GLIMR development environment.

## Changes Made
- ✅ Added NSG diagnostics policy assignment for subscription `d24c931e-2e6d-4508-8583-85ac42715580`
- ✅ Scoped assignment to `glimr-rg-dev` resource group only
- ✅ Configured to forward NSG logs to SOC Event Hub
- ✅ Uses existing SOC managed identity for Event Hub access

## Policy Details
- **Policy**: `HMCTSNSGDiagnostic` (Diagnostic Settings for NSG to SOC)
- **Scope**: Resource group level - `/subscriptions/d24c931e-2e6d-4508-8583-85ac42715580/resourceGroups/glimr-rg-dev`
- **Event Hub**: `network-security-group` in SOC Event Hub namespace
- **Profile**: `NSG-SOC-Prod-GLIMR`

## Impact
- Only affects Network Security Groups created within the `glimr-rg-dev` resource group
- Automatic diagnostic settings configuration for NSGs in the target resource group
- Enhanced monitoring and compliance for GLIMR development environment

## Testing
- [x] File structure follows existing patterns
- [x] Uses same Event Hub configuration as other diagnostic policies
- [x] Proper managed identity configuration

## Related
- Part of DTSPO-27183 GLIMR development work
- First usage of the NSG diagnostics policy in the workspace