### PR TITLE
DTSPO-27242: Add NSG diagnostics policy assignments for GLIMR staging and production subscriptions

### DIFF
--- a/assignments/subscriptions/17390ec1-5a5e-4a20-afb3-38d8d726ae45/assign.nsg_diagnostics_rg-prod.json
+++ b/assignments/subscriptions/17390ec1-5a5e-4a20-afb3-38d8d726ae45/assign.nsg_diagnostics_rg-prod.json
@@ -1,0 +1,45 @@
+{
+    "properties": {
+        "metadata": {
+            "assignedBy": "https://github.com/hmcts/azure-policy"
+        },
+        "description": "Forwards Network Security Group Logs from prod resource group to Azure Event Hub - MOJ",
+        "displayName": "HMCTS Collect NSG Logs prod (Production Subscription)",
+        "enforcementMode": "Default",
+        "nonComplianceMessages": [],
+        "notScopes": [],
+        "parameters": {
+            "profileName": {
+                "value": "nsgToEventHubMOJ"
+            },
+            "eventHubName": {
+                "value": "azure-resource-events"
+            },
+            "eventHubAuthRule": {
+                "value": "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-xsiam-eventhubs-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod-xsiam-eventhubns/authorizationrules/soc-xsiam-eventhub-namespace-sender"
+            },
+            "eventHubLocation": {
+                "value": "uksouth"
+            },
+            "logsEnabled": {
+                "value": "True"
+            }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSNSGDiagnostic",
+        "scope": "/subscriptions/17390ec1-5a5e-4a20-afb3-38d8d726ae45/resourceGroups/InternalSpoke-rg"
+    },
+    "location": "uksouth",
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/soc-prod-eventhub-azure-policy": {}
+        }
+    },
+    "sku": {
+        "name": "A0",
+        "tier": "Free"
+    },
+    "type": "Microsoft.Authorization/policyAssignments",
+    "id": "/subscriptions/17390ec1-5a5e-4a20-afb3-38d8d726ae45/resourceGroups/InternalSpoke-rg/providers/Microsoft.Authorization/policyAssignments/HMCTSNSGDiagnostic_prod",
+    "name": "HMCTSNSGDiagnostic_prod"
+}

--- a/assignments/subscriptions/ae75b9fb-7d34-4112-82ff-64bd3855ce27/assign.nsg_diagnostics_rg-stg.json
+++ b/assignments/subscriptions/ae75b9fb-7d34-4112-82ff-64bd3855ce27/assign.nsg_diagnostics_rg-stg.json
@@ -1,0 +1,45 @@
+{
+    "properties": {
+        "metadata": {
+            "assignedBy": "https://github.com/hmcts/azure-policy"
+        },
+        "description": "Forwards Network Security Group Logs from stg resource group to Azure Event Hub - MOJ",
+        "displayName": "HMCTS Collect NSG Logs stg (Staging Subscription)",
+        "enforcementMode": "Default",
+        "nonComplianceMessages": [],
+        "notScopes": [],
+        "parameters": {
+            "profileName": {
+                "value": "nsgToEventHubMOJ"
+            },
+            "eventHubName": {
+                "value": "azure-resource-events"
+            },
+            "eventHubAuthRule": {
+                "value": "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-xsiam-eventhubs-prod-rg/providers/Microsoft.EventHub/namespaces/soc-prod-xsiam-eventhubns/authorizationrules/soc-xsiam-eventhub-namespace-sender"
+            },
+            "eventHubLocation": {
+                "value": "uksouth"
+            },
+            "logsEnabled": {
+                "value": "True"
+            }
+        },
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSNSGDiagnostic",
+        "scope": "/subscriptions/ae75b9fb-7d34-4112-82ff-64bd3855ce27/resourceGroups/InternalSpoke-rg"
+    },
+    "location": "uksouth",
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/soc-prod-eventhub-azure-policy": {}
+        }
+    },
+    "sku": {
+        "name": "A0",
+        "tier": "Free"
+    },
+    "type": "Microsoft.Authorization/policyAssignments",
+    "id": "/subscriptions/ae75b9fb-7d34-4112-82ff-64bd3855ce27/resourceGroups/InternalSpoke-rg/providers/Microsoft.Authorization/policyAssignments/HMCTSNSGDiagnostic_stg",
+    "name": "HMCTSNSGDiagnostic_stg"
+}


### PR DESCRIPTION
## Summary

This PR adds NSG diagnostics policy assignments for GLIMR staging and production subscriptions to enable Network Security Group log forwarding to Azure Event Hub for MOJ compliance.

## Changes

- ✅ Added NSG diagnostics policy assignment for GLIMR staging subscription (`ae75b9fb-7d34-4112-82ff-64bd3855ce27`)
- ✅ Added NSG diagnostics policy assignment for GLIMR production subscription (`17390ec1-5a5e-4a20-afb3-38d8d726ae45`)

## Details

Both policy assignments:
- Forward NSG logs to Azure Event Hub (`azure-resource-events`)
- Use the same Event Hub authorization rule and managed identity as existing assignments
- Target the `InternalSpoke-rg` resource group in each subscription
- Follow the established naming convention and configuration patterns

## Files Added

- `assignments/subscriptions/ae75b9fb-7d34-4112-82ff-64bd3855ce27/assign.nsg_diagnostics_rg-stg.json`
- `assignments/subscriptions/17390ec1-5a5e-4a20-afb3-38d8d726ae45/assign.nsg_diagnostics_rg-prod.json`

## Testing

Please verify the policy assignments are correctly configured for the target subscriptions and resource groups.

---
**JIRA Ticket:** DTSPO-27242