### PR TITLE
Dtspo 27301 fix policy errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ When you've decided on a scope, create a policy assignment file in the appropria
 
 Use a subscription scope when you are testing out a policy or if you only want a policy to apply to a single subscription or group of subscriptions.
 
+When testing policy assignments against Sandbox, if the policy you are assigning is a built in Azure policy make sure to prefix the policy file with `builtin.assign.*`
+so that the policy definition id is not overriden like it is done for custom policies, you can view how this works in sandbox-override.sh
+
 Use a management group scope when you want a policy to apply to all subscriptions in the tenant.
 
 **If a tagging policy exception is required, please use the notScopes in assignments/mgmt-groups/mg-HMCTS/assign.tagging.json**

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.cluster_admin_restrict.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.cluster_admin_restrict.json
@@ -6,11 +6,6 @@
     "description": "Audit AKS clusters which do not follow the principle of least privilege when using admin role.",
     "displayName": "AKS Cluster-Admin Role Restriction (mg:CFT-Sandbox)",
     "enforcementMode": "Default",
-    "nonComplianceMessages": [
-      {
-        "message": "Clusters should ensure that the cluster-admin role is only used where required."
-      }
-    ],
     "notScopes": [],
     "parameters": {
       "effect": {

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.disable_automount_creds.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.disable_automount_creds.json
@@ -6,11 +6,6 @@
     "description": "Audit AKS clusters which do not have automounting API credentials disabled.",
     "displayName": "AKS Disable Automount API Credentials (mg:CFT-Sandbox)",
     "enforcementMode": "Default",
-    "nonComplianceMessages": [
-      {
-        "message": "Clusters should disable automounting API credentials."
-      }
-    ],
     "notScopes": [],
     "parameters": {
       "effect": {

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.internal_load_balancers.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.internal_load_balancers.json
@@ -6,15 +6,10 @@
     "description": "Audit AKS Clusters which do not use internal load balancers.",
     "displayName": "AKS Use Internal Load Balancers (mg:CFT-Sandbox)",
     "enforcementMode": "Default",
-    "nonComplianceMessages": [
-      {
-        "message": "AKS Clusters should use internal load balancers."
-      }
-    ],
     "notScopes": [],
     "parameters": {
       "effect": {
-        "value": "Audit"
+        "value": "Deny"
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/3fc4dc25-5baf-40d8-9b05-7fe74c1bc64e",

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.minimize_wildcards.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.minimize_wildcards.json
@@ -6,11 +6,6 @@
     "description": "Audit AKS Clusters which do not minimise wildcard use in role and cluster role.",
     "displayName": "AKS Minimize Wildcard Permissions (mg:CFT-Sandbox)",
     "enforcementMode": "Default",
-    "nonComplianceMessages": [
-      {
-        "message": "Clusters should minimise wildcard use in role and cluster role."
-      }
-    ],
     "notScopes": [],
     "parameters": {
       "effect": {

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.no_default_namespace.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.no_default_namespace.json
@@ -6,15 +6,10 @@
     "description": "Audit AKS Clusters which use the default namespace.",
     "displayName": "AKS No Default Namespace (mg:CFT-Sandbox)",
     "enforcementMode": "Default",
-    "nonComplianceMessages": [
-      {
-        "message": "AKS Clusters should not use the default namespace."
-      }
-    ],
     "notScopes": [],
     "parameters": {
       "effect": {
-        "value": "DeployIfNotExists"
+        "value": "Deny"
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/9f061a12-e40d-4183-a00e-171812443373",

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.no_endpoint_edit.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.aks.no_endpoint_edit.json
@@ -6,11 +6,6 @@
     "description": "Audit AKS Clusters which allow endpoint edit permissions of ClusterRole/system:aggregate-to-edit.",
     "displayName": "AKS No Endpoint Edit Permissions (mg:CFT-Sandbox)",
     "enforcementMode": "Default",
-    "nonComplianceMessages": [
-      {
-        "message": "AKS Clusters should not allow endpoint edit permissions of ClusterRole/system:aggregate-to-edit."
-      }
-    ],
     "notScopes": [],
     "parameters": {
       "effect": {

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.dsbl_cmd_invk_k_clusters.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.dsbl_cmd_invk_k_clusters.json
@@ -6,11 +6,6 @@
     "description": "Audit AKS clusters where Run Command (command invoke) is not disabled.",
     "displayName": "AKS Disable Command Invoke (mg:CFT-Sandbox)",
     "enforcementMode": "Default",
-    "nonComplianceMessages": [
-      {
-        "message": "Command invoke should be disabled on AKS clusters."
-      }
-    ],
     "notScopes": [],
     "parameters": {
       "effect": {
@@ -27,5 +22,11 @@
   "sku": {
     "name": "A0",
     "tier": "Free"
+  },
+  "identity": {
+    "type": "UserAssigned",
+    "userAssignedIdentities": {
+      "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-sbox-mi": {}
+    }
   }
 }

--- a/pipeline-scripts/sandbox-override.sh
+++ b/pipeline-scripts/sandbox-override.sh
@@ -2,6 +2,9 @@
 set -ex
 
 export SUB_ASSIGNMENTS=$(find ./assignments/$SUB  -type f -name 'assign.*.json')
+# Where we want to test assignment of policies which are already built into Azure process those separately
+# Without modifying the policyDefinitionId to point to a custom created policy definition
+export BUILTIN_SUB_ASSIGNMENTS=$(find ./assignments/$SUB -type f -name 'builtin.assign.*.json')
 export MGMT_ASSIGNMENTS=$(find ./assignments/mgmt-groups/mg-cft-sandbox -type f -name 'assign.*.json')
 export POLICIES=$(find ./policies -name policy.json -type f )
 export ENVIRONMENT=${ENVIRONMENT:-Sandbox}
@@ -25,21 +28,42 @@ for policy in ${POLICIES}; do
 
 done
 
-echo "Creating Sandbox Subscription Assignments"
-for assignment in ${SUB_ASSIGNMENTS}; do
+process_subscription_assignment() {
+    assignment=$1
+    built_in_assignment=$2
+
     FILE=$(basename ${assignment})
     DIR=$(basename "$(dirname ${assignment})" )
     mkdir -p ${ASSIGNMENTS_DIR}/${DIR}
+    if [ "$built_in_assignment" = true ]; then
+        echo "Creating file for built-in policy: ${ASSIGNMENTS_DIR}/${DIR}/${FILE}"
+        CUSTOM_POLICY_DEFINITION_ID=""
+        npx json -f ${assignment} \
+        -e 'this.properties.scope=process.env.SUB' \
+        -e 'this.name=this.name + "_" + process.env.ENVIRONMENT' \
+        -e 'this.properties.displayName=this.properties.displayName + " - " + process.env.ENVIRONMENT ' \
+        -e 'this.properties.policyDefinitionId=this.properties.policyDefinitionId' \
+        -e 'this.properties.notScopes=[]' \
+        -e 'this.id=process.env.SUB + "/providers/Microsoft.Authorization/policyAssignments/" + this.name' > ${ASSIGNMENTS_DIR}/${DIR}/${FILE}
+    else
+        echo "Creating file for custom policy: ${ASSIGNMENTS_DIR}/${DIR}/${FILE}"
+        npx json -f ${assignment} \
+        -e 'this.properties.scope=process.env.SUB' \
+        -e 'this.name=this.name + "_" + process.env.ENVIRONMENT' \
+        -e 'this.properties.displayName=this.properties.displayName + " - " + process.env.ENVIRONMENT ' \
+        -e 'this.properties.policyDefinitionId=process.env.SUB + "/providers/Microsoft.Authorization/policyDefinitions/" + this.properties.policyDefinitionId.split("/").pop() + process.env.ENVIRONMENT' \
+        -e 'this.properties.notScopes=[]' \
+        -e 'this.id=process.env.SUB + "/providers/Microsoft.Authorization/policyAssignments/" + this.name' > ${ASSIGNMENTS_DIR}/${DIR}/${FILE}
+    fi
+}
 
-    echo "Creating file: ${ASSIGNMENTS_DIR}/${DIR}/${FILE}"
-    npx json -f ${assignment} \
-    -e 'this.properties.scope=process.env.SUB' \
-    -e 'this.name=this.name + "_" + process.env.ENVIRONMENT' \
-    -e 'this.properties.displayName=this.properties.displayName + " - " + process.env.ENVIRONMENT ' \
-    -e 'this.properties.policyDefinitionId=process.env.SUB + "/providers/Microsoft.Authorization/policyDefinitions/" + this.properties.policyDefinitionId.split("/").pop() + process.env.ENVIRONMENT' \
-    -e 'this.properties.notScopes=[]' \
-    -e 'this.id=process.env.SUB + "/providers/Microsoft.Authorization/policyAssignments/" + this.name' > ${ASSIGNMENTS_DIR}/${DIR}/${FILE}
+echo "Creating Sandbox Subscription Assignments"
+for assignment in ${SUB_ASSIGNMENTS}; do
+    process_subscription_assignment "$assignment" false
+done
 
+for assignment in ${BUILTIN_SUB_ASSIGNMENTS}; do
+    process_subscription_assignment "$assignment" true
 done
 
 ## Commented out for now, this will not work with policies created at subscription level as we do above (line 15).


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-27301

### Change description
Fix couple errors reported after merging:
- Remove non-compliance messages on new policies as they are not supported for these
- Change load balancers policy to DENY as we are already compliant with this
- Change no default namespaces policy to Deny as it does not have "DeployIfNotExists" effect value
- Add userAssigned identity config to cluster command invoke policy as this is required for remediation when using "deployIfNotExists" effect
- Modify sandbox-override.sh script so that it supports testing from a PR of assignments for both newly added custom policies as well as built-in azure policies

### Testing done
After modifying current sandbox testing script to accept built in policies I verified that each policy was created on sandbox subscription.
Load Balancers and default namespace policies we were already compliant with, while the command invoke policy we are not on sandbox

### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
