### PR TITLE
Move policies listed in DTSPO-27227 from sandbox management group to wider hmcts-mg

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.aad_integration.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.aad_integration.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS clusters without Microsoft Entra ID (AAD) managed integration enabled.",
-    "displayName": "AKS Entra ID Integration (mg:CFT-Sandbox)",
+    "displayName": "AKS Entra ID Integration - HMCTS-MG",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.cluster_autoupgrade.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.cluster_autoupgrade.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS clusters that do not have an allowed cluster auto-upgrade channel configured.",
-    "displayName": "AKS Cluster Auto-upgrade (mg:CFT-Sandbox)",
+    "displayName": "AKS Cluster Auto-upgrade - HMCTS-MG",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.disable_runcommand.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.disable_runcommand.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS clusters where Run Command (command invoke) is not disabled.",
-    "displayName": "AKS Disable RunCommand (mg:CFT-Sandbox)",
+    "displayName": "AKS Disable RunCommand - HMCTS-MG",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.disable_ssh.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.disable_ssh.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS clusters that have SSH access enabled (should be disabled or local user only).",
-    "displayName": "AKS Disable SSH (mg:CFT-Sandbox)",
+    "displayName": "AKS Disable SSH - HMCTS-MG",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.enable_csi.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.enable_csi.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS clusters that do not have CSI drivers enabled as per parameters (Disk/File/Snapshot).",
-    "displayName": "AKS Enable CSI (mg:CFT-Sandbox)",
+    "displayName": "AKS Enable CSI - HMCTS-MG",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.nodeos_autoupgrade.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.nodeos_autoupgrade.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS clusters that do not have allowed node OS auto-upgrade channels configured when cluster channel is node-image.",
-    "displayName": "AKS Node OS Auto-upgrade (mg:CFT-Sandbox)",
+    "displayName": "AKS Node OS Auto-upgrade - HMCTS-MG",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.use_cni.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.use_cni.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS clusters not using Azure CNI.",
-    "displayName": "AKS Use Azure CNI (mg:CFT-Sandbox)",
+    "displayName": "AKS Use Azure CNI - HMCTS-MG",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-27227

### Change description
Move audit mode policies we already tested in Sandbox into wider HMCTS Management Group.

### Testing done
These were already tested in Sandbox and are set to audit mode only.
Within Sandbox all were already compliant besides disable ssh and disable run command

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
