### PR TITLE
Fix silly mistake where scopes were still pointing at sandbox after moving the policy files into hmcts-mg folder

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.aad_integration.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.aad_integration.json
@@ -18,11 +18,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/450d2877-ebea-41e8-b00c-e286317d21bf",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/AKSAADIntegration-sbox",
-  "name": "AKSAADIntegration-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSAADIntegration",
+  "name": "AKSAADIntegration",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.cluster_autoupgrade.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.cluster_autoupgrade.json
@@ -23,11 +23,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/5c345cdf-2049-47e0-b8fe-b0e96bc2df35",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/AKSClusterAutoUpg-sbox",
-  "name": "AKSClusterAutoUpg-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSClusterAutoUpgrade",
+  "name": "AKSClusterAutoUpgrade",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.disable_runcommand.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.disable_runcommand.json
@@ -18,11 +18,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/89f2d532-c53c-4f8f-9afa-4927b1114a0d",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/AKSDisableRunCmd-sbox",
-  "name": "AKSDisableRunCmd-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSDisableRunCommand",
+  "name": "AKSDisableRunCommand",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.disable_ssh.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.disable_ssh.json
@@ -18,11 +18,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/28257686-e9db-403e-b9e2-a5eecbe03da9",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/AKSDisableSSH-sbox",
-  "name": "AKSDisableSSH-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSDisableSSH",
+  "name": "AKSDisableSSH",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.enable_csi.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.enable_csi.json
@@ -27,11 +27,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/c5110b6e-5272-4989-9935-59ad06fdf341",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/AKSEnableCSI-sbox",
-  "name": "AKSEnableCSI-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSEnableCSIDriver",
+  "name": "AKSEnableCSIDriver",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.nodeos_autoupgrade.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.nodeos_autoupgrade.json
@@ -23,11 +23,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/04408ca5-aa10-42ce-8536-98955cdddd4c",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/AKSNodeOSAutoUpg-sbox",
-  "name": "AKSNodeOSAutoUpg-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSNodeOSAutoUpgrade",
+  "name": "AKSNodeOSAutoUpgrade",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.use_cni.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.use_cni.json
@@ -18,11 +18,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/46238e2f-3f6f-4589-9f3f-77bed4116e67",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/AKSUseAzureCNI-sbox",
-  "name": "AKSUseAzureCNI-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSUseAzureCNI",
+  "name": "AKSUseAzureCNI",
   "location": "uksouth",
   "sku": {
     "name": "A0",


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-27227

### Change description
Fix silly mistake where scopes were still pointing at sandbox after moving the policy files into hmcts-mg folder.
This meant that the moved policies were only created in sandbox again and not actually the wider hmcts mg.

### Testing done
N/A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
