### PR TITLE
Move policies listed in DTSPO-27303 from sbox-mg to hmcts-mg

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.cluster_admin_restrict.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.cluster_admin_restrict.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS clusters which do not follow the principle of least privilege when using admin role.",
-    "displayName": "AKS Cluster-Admin Role Restriction (mg:CFT-Sandbox)",
+    "displayName": "AKS Cluster-Admin Role Restriction - HMCTS-MG",
     "enforcementMode": "Default",
     "notScopes": [],
     "parameters": {
@@ -13,11 +13,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a3dc4946-dba6-43e6-950d-f96532848c9f",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/K8sClstrAdmnRstrict-sbox",
-  "name": "K8sClstrAdmnRstrict-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/K8sClusterAdminRestrict",
+  "name": "K8sClusterAdminRestrict",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.disable_automount_creds.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.disable_automount_creds.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS clusters which do not have automounting API credentials disabled.",
-    "displayName": "AKS Disable Automount API Credentials (mg:CFT-Sandbox)",
+    "displayName": "AKS Disable Automount API Credentials - HMCTS-MG",
     "enforcementMode": "Default",
     "notScopes": [],
     "parameters": {
@@ -13,11 +13,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/423dd1ba-798e-40e4-9c4d-b6902674b423",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/K8sDsblAutomntCreds-sbox",
-  "name": "K8sDsblAutomntCreds-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/K8sDisableAutomountCreds",
+  "name": "K8sDisableAutomountCreds",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.internal_load_balancers.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.internal_load_balancers.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS Clusters which do not use internal load balancers.",
-    "displayName": "AKS Use Internal Load Balancers (mg:CFT-Sandbox)",
+    "displayName": "AKS Use Internal Load Balancers - HMCTS-MG",
     "enforcementMode": "Default",
     "notScopes": [],
     "parameters": {
@@ -13,11 +13,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/3fc4dc25-5baf-40d8-9b05-7fe74c1bc64e",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/K8sUseInternalLB-sbox",
-  "name": "K8sUseInternalLB-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/K8sClusterUseInternalLB",
+  "name": "K8sClusterUseInternalLB",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.minimize_wildcards.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.minimize_wildcards.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS Clusters which do not minimise wildcard use in role and cluster role.",
-    "displayName": "AKS Minimize Wildcard Permissions (mg:CFT-Sandbox)",
+    "displayName": "AKS Minimize Wildcard Permissions - HMCTS-MG",
     "enforcementMode": "Default",
     "notScopes": [],
     "parameters": {
@@ -13,11 +13,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ca8d5704-aa2b-40cf-b110-dc19052825ad",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/K8sMinmiseWildcards-sbox",
-  "name": "K8sMinmiseWildcards-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/K8sMinimiseWildcardUse",
+  "name": "K8sMinimiseWildcardUse",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.no_default_namespace.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.no_default_namespace.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS Clusters which use the default namespace.",
-    "displayName": "AKS No Default Namespace (mg:CFT-Sandbox)",
+    "displayName": "AKS No Default Namespace - HMCTS-MG",
     "enforcementMode": "Default",
     "notScopes": [],
     "parameters": {
@@ -13,11 +13,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/9f061a12-e40d-4183-a00e-171812443373",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/K8sNoDfltNamespace-sbox",
-  "name": "K8sNoDfltNamespace-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/K8sNoDefaultNamespace",
+  "name": "K8sNoDefaultNamespace",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.aks.no_endpoint_edit.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.aks.no_endpoint_edit.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS Clusters which allow endpoint edit permissions of ClusterRole/system:aggregate-to-edit.",
-    "displayName": "AKS No Endpoint Edit Permissions (mg:CFT-Sandbox)",
+    "displayName": "AKS No Endpoint Edit Permissions - HMCTS-MG",
     "enforcementMode": "Default",
     "notScopes": [],
     "parameters": {
@@ -13,11 +13,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1ddac26b-ed48-4c30-8cc5-3a68c79b8001",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/K8sNoEndpointEdit-sbox",
-  "name": "K8sNoEndpointEdit-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/K8sNoEndpointEdit",
+  "name": "K8sNoEndpointEdit",
   "location": "uksouth",
   "sku": {
     "name": "A0",

--- a/assignments/mgmt-groups/mg-HMCTS/assign.dsbl_cmd_invk_k_clusters.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.dsbl_cmd_invk_k_clusters.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Audit AKS clusters where Run Command (command invoke) is not disabled.",
-    "displayName": "AKS Disable Command Invoke (mg:CFT-Sandbox)",
+    "displayName": "AKS Disable Command Invoke - HMCTS-MG",
     "enforcementMode": "Default",
     "notScopes": [],
     "parameters": {
@@ -13,11 +13,11 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1b708b0a-3380-40e9-8b79-821f9fa224cc",
-    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/AKSDisableCmdInvoke-sbox",
-  "name": "AKSDisableCmdInvoke-sbox",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSDisableCommanddInvoke",
+  "name": "AKSDisableCommandInvoke",
   "location": "uksouth",
   "sku": {
     "name": "A0",
@@ -26,7 +26,7 @@
   "identity": {
     "type": "UserAssigned",
     "userAssignedIdentities": {
-      "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-sbox-mi": {}
+      "/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-prod-mi": {}
     }
   }
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-27303

### Change description
Move policies listed in DTSPO-27303 from sandbox Management Group to wider HMCTS Management Group
Replace `aks-sbox-mi` with `aks-prod-mi` Managed Identity for "Disable Command Invoke" policy.

### Testing done
These policies have been created in Sandbox Management Group and did not see any issues so far.
`DeployIfNotExists` will not remediate immediately, instead a remediation task has to be created after this assignment is created so this shouldn't break anything either.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
