### PR TITLE
Fix a typo in the id of aks command invoke disable policy

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.dsbl_cmd_invk_k_clusters.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.dsbl_cmd_invk_k_clusters.json
@@ -16,7 +16,7 @@
     "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSDisableCommanddInvoke",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSDisableCommandInvoke",
   "name": "AKSDisableCommandInvoke",
   "location": "uksouth",
   "sku": {


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-27303

### Change description
Made a typo in the policy id AKSDisableComman`dd`Invoke instead of AKSDisableComman`d`Invoke

### Testing done
Last policy action run has failed due to mismatch in policy id and the name

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
