### PR TITLE
feat: add bastion-prod resource group to allowed disk SKU exclusion list

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_disk_sku.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_disk_sku.json
@@ -26,7 +26,8 @@
       "/subscriptions/b7d2bd5f-b744-4acc-9c73-e068cec2e8d8/resourceGroups/atlassian-nonprod-rg",
       "/subscriptions/79898897-729c-41a0-a5ca-53c764839d95/resourceGroups/atlassian-prod-rg",
       "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/darts-migration-stg-rg",
-      "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/darts-migration-prod-rg"
+      "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/darts-migration-prod-rg",
+      "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/bastion-prod-rg"
     ],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSDiskSkuSize",


### PR DESCRIPTION
### Jira link

See [DTSPO-27470](https://tools.hmcts.net/jira/browse/DTSPO-27470)

### Change description

Temporarily add bastion-prod resource group to the exclusion list for the allowed disk SKU policy. This is needed for restoring ServiceNow MySQL database. This database is 500GB compressed and in order to load it into MySQL instance we need to parallelize the process, with single-core workload the process would take 30 days. In order to do that, we first need to split that SQL db backup into separate files so that it can be processed in parallel. For that a disk larger than 2TB is needed on the bastion VM (which we use for the restore process).

### Testing done

N/A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] (No) Does this PR introduce a breaking change
