### PR TITLE
Update scope of aks admin groups to subscriptions

### DIFF
--- a/assignments/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/assign.aks.aad_admin_groups.json
+++ b/assignments/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/assign.aks.aad_admin_groups.json
@@ -24,7 +24,7 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/36a27de4-199b-40fb-b336-945a8475d6c5",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
   },
   "type": "Microsoft.Authorization/policyAssignments",
   "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSAADAdmGrp-ptlsbox",

--- a/assignments/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/assign.aks.aad_admin_groups.json
+++ b/assignments/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/assign.aks.aad_admin_groups.json
@@ -24,7 +24,7 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/36a27de4-199b-40fb-b336-945a8475d6c5",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
   },
   "type": "Microsoft.Authorization/policyAssignments",
   "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSAADAdmGrp-ptl",

--- a/assignments/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/assign.aks.aad_admin_groups.json
+++ b/assignments/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/assign.aks.aad_admin_groups.json
@@ -24,7 +24,7 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/36a27de4-199b-40fb-b336-945a8475d6c5",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09"
   },
   "type": "Microsoft.Authorization/policyAssignments",
   "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSAADAdmGrp-ithc",

--- a/assignments/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/assign.aks.aad_admin_groups.json
+++ b/assignments/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/assign.aks.aad_admin_groups.json
@@ -24,7 +24,7 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/36a27de4-199b-40fb-b336-945a8475d6c5",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c"
   },
   "type": "Microsoft.Authorization/policyAssignments",
   "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSAADAdmGrp-perftest",

--- a/assignments/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/assign.aks.aad_admin_groups.json
+++ b/assignments/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/assign.aks.aad_admin_groups.json
@@ -24,7 +24,7 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/36a27de4-199b-40fb-b336-945a8475d6c5",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4"
   },
   "type": "Microsoft.Authorization/policyAssignments",
   "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSAADAdmGrp-preview",

--- a/assignments/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/assign.aks.aad_admin_groups.json
+++ b/assignments/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/assign.aks.aad_admin_groups.json
@@ -24,7 +24,7 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/36a27de4-199b-40fb-b336-945a8475d6c5",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27"
   },
   "type": "Microsoft.Authorization/policyAssignments",
   "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSAADAdmGrp-prod",

--- a/assignments/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/assign.aks.aad_admin_groups.json
+++ b/assignments/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/assign.aks.aad_admin_groups.json
@@ -24,7 +24,7 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/36a27de4-199b-40fb-b336-945a8475d6c5",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7"
   },
   "type": "Microsoft.Authorization/policyAssignments",
   "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSAADAdmGrp-aat",

--- a/assignments/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/assign.aks.aad_admin_groups.json
+++ b/assignments/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/assign.aks.aad_admin_groups.json
@@ -24,7 +24,7 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/36a27de4-199b-40fb-b336-945a8475d6c5",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060"
   },
   "type": "Microsoft.Authorization/policyAssignments",
   "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSAADAdmGrp-demo",


### PR DESCRIPTION
### Change description

AKS Admin group policies are showing as non compliant because they're being applied at the wrong scope
They have to be applied at the subscription scope due to the subscription specific groups

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
