### PR TITLE
Remove deleted subscription from vpn policy

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.vpn.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.vpn.json
@@ -8,8 +8,7 @@
         "enforcementMode": "Default",
         "notScopes": [
             "/subscriptions/28d33a47-7c14-456d-9a40-ce9c9b5a3937/",
-            "/subscriptions/55c2f45e-1381-4b17-9bd0-f85215b8bb4f/",
-            "/subscriptions/3d84f717-22a0-4f4e-aac7-5ff8f4ee0a90/"
+            "/subscriptions/55c2f45e-1381-4b17-9bd0-f85215b8bb4f/"
         ],
         "parameters": {},
         "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/VPNConnectionRequired",


### PR DESCRIPTION
### Change description

It's blocking github actions from working
The subscription looks to have been deleted
https://github.com/hmcts/azure-enterprise/pull/118/files

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
