### PR TITLE
Fix AKS maintenance policy scopes

### DIFF
--- a/assignments/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/assign.aks.planned_maintenance.json
+++ b/assignments/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/assign.aks.planned_maintenance.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Configure planned maintenance window for AKS clusters.",
-    "displayName": "AKS Planned Maintenance (mg:HMCTS)",
+    "displayName": "AKS Planned Maintenance (DTS-CFTSBOX-INTSVC",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
@@ -37,10 +37,10 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1352e44-d34d-4e4d-a22e-451a15f759a1",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-ptlsbox",
+  "id": "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-ptlsbox",
   "name": "AKSPlanMaint-ptlsbox",
   "location": "uksouth",
   "sku": {

--- a/assignments/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/assign.aks.planned_maintenance.json
+++ b/assignments/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/assign.aks.planned_maintenance.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Configure planned maintenance window for AKS clusters.",
-    "displayName": "AKS Planned Maintenance (mg:HMCTS)",
+    "displayName": "AKS Planned Maintenance (DTS-CFTPTL-INTSVC)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
@@ -37,10 +37,10 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1352e44-d34d-4e4d-a22e-451a15f759a1",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-ptl",
+  "id": "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-ptl",
   "name": "AKSPlanMaint-ptl",
   "location": "uksouth",
   "sku": {

--- a/assignments/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/assign.aks.planned_maintenance.json
+++ b/assignments/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/assign.aks.planned_maintenance.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Configure planned maintenance window for AKS clusters.",
-    "displayName": "AKS Planned Maintenance (mg:HMCTS)",
+    "displayName": "AKS Planned Maintenance (DCD-CFTAPPS-ITHC)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
@@ -37,10 +37,10 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1352e44-d34d-4e4d-a22e-451a15f759a1",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-ithc",
+  "id": "/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-ithc",
   "name": "AKSPlanMaint-ithc",
   "location": "uksouth",
   "sku": {

--- a/assignments/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/assign.aks.planned_maintenance.json
+++ b/assignments/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/assign.aks.planned_maintenance.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Configure planned maintenance window for AKS clusters.",
-    "displayName": "AKS Planned Maintenance (mg:HMCTS)",
+    "displayName": "AKS Planned Maintenance (DCD-CFTAPPS-PERFTEST)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
@@ -37,10 +37,10 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1352e44-d34d-4e4d-a22e-451a15f759a1",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-perftest",
+  "id": "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-perftest",
   "name": "AKSPlanMaint-perftest",
   "location": "uksouth",
   "sku": {

--- a/assignments/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/assign.aks.planned_maintenance.json
+++ b/assignments/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/assign.aks.planned_maintenance.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Configure planned maintenance window for AKS clusters.",
-    "displayName": "AKS Planned Maintenance (mg:HMCTS)",
+    "displayName": "AKS Planned Maintenance (DCD-CFTAPPS-DEV)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
@@ -37,10 +37,10 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1352e44-d34d-4e4d-a22e-451a15f759a1",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-preview",
+  "id": "/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-preview",
   "name": "AKSPlanMaint-preview",
   "location": "uksouth",
   "sku": {

--- a/assignments/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/assign.aks.planned_maintenance.json
+++ b/assignments/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/assign.aks.planned_maintenance.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Configure planned maintenance window for AKS clusters.",
-    "displayName": "AKS Planned Maintenance (mg:HMCTS)",
+    "displayName": "AKS Planned Maintenance (DCD-CFTAPPS-PROD)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
@@ -37,10 +37,10 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1352e44-d34d-4e4d-a22e-451a15f759a1",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-prod",
+  "id": "/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-prod",
   "name": "AKSPlanMaint-prod",
   "location": "uksouth",
   "sku": {

--- a/assignments/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/assign.aks.planned_maintenance.json
+++ b/assignments/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/assign.aks.planned_maintenance.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Configure planned maintenance window for AKS clusters.",
-    "displayName": "AKS Planned Maintenance (mg:HMCTS)",
+    "displayName": "AKS Planned Maintenance (DCD-CFTAPPS-STG)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
@@ -37,10 +37,10 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1352e44-d34d-4e4d-a22e-451a15f759a1",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-aat",
+  "id": "/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-aat",
   "name": "AKSPlanMaint-aat",
   "location": "uksouth",
   "sku": {

--- a/assignments/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/assign.aks.planned_maintenance.json
+++ b/assignments/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/assign.aks.planned_maintenance.json
@@ -4,7 +4,7 @@
       "assignedBy": "github.com/hmcts/azure-policy"
     },
     "description": "Configure planned maintenance window for AKS clusters.",
-    "displayName": "AKS Planned Maintenance (mg:HMCTS)",
+    "displayName": "AKS Planned Maintenance (DCD-CFTAPPS-DEMO)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
@@ -37,10 +37,10 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1352e44-d34d-4e4d-a22e-451a15f759a1",
-    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+    "scope": "/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060"
   },
   "type": "Microsoft.Authorization/policyAssignments",
-  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-demo",
+  "id": "/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/providers/Microsoft.Authorization/policyAssignments/AKSPlanMaint-demo",
   "name": "AKSPlanMaint-demo",
   "location": "uksouth",
   "sku": {


### PR DESCRIPTION
### Change description

Update scopes and display names of aks maintenance policies
Currently applied at mgmt group scope but each one has its own identity to apply which means too many are showing as in scope

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
