### PR TITLE
SIDM-10276 exempt sandbox Service Bus Premium SKU

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_servicebus_sku.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_servicebus_sku.json
@@ -38,6 +38,7 @@
       "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/civil-sdt-aat/providers/microsoft.servicebus/namespaces/civil-sdt-servicebus-aat",
       "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/sscs-perftest/providers/microsoft.servicebus/namespaces/sscs-servicebus-perftest",
       "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/sscs-ithc/providers/microsoft.servicebus/namespaces/sscs-servicebus-ithc",
+      "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourcegroups/idam-idam-sandbox/providers/microsoft.servicebus/namespaces/idam-servicebus-sandbox",
       "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourcegroups/idam-idam-prod/providers/microsoft.servicebus/namespaces/idam-servicebus-prod",
       "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourcegroups/rd-prod/providers/microsoft.servicebus/namespaces/rd-servicebus-prod",
       "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourcegroups/reform-scan-prod/providers/microsoft.servicebus/namespaces/reform-scan-servicebus-prod-premium",


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/SIDM-10276

### Change description

- Adds a resource-level exemption to the allowed_servicebus_sku policy assignment for idam-servicebus-sandbox.
- This allows the sandbox Service Bus namespace to use the Premium SKU required for private endpoint testing.
- Resource exempted: /subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourcegroups/idam-idam-sandbox/providers/microsoft.servicebus/namespaces/idam-servicebus-sandbox