### PR TITLE
DTSPO-32627 - Add RBAC policy to deny direct user role assignments

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.rbac_no_direct_user_assignment.json
@@ -11,7 +11,9 @@
         "message": "Direct user RBAC role assignments are not permitted. Time-bound PIM eligible assignments for restricted privileged administrator roles are also not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
       }
     ],
-    "notScopes": [],
+    "notScopes": [
+      "/subscriptions/6c4d2513-a873-41b4-afdd-b05a33206631/resourceGroups/central-app-registration-rg/providers/Microsoft.KeyVault/vaults/central-app-reg-kv"
+    ],
     "parameters": {
       "effect": {
         "value": "Deny"

--- a/assignments/mgmt-groups/mg-HMCTS/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.rbac_no_direct_user_assignment.json
@@ -3,12 +3,12 @@
     "metadata": {
       "assignedBy": "github.com/hmcts/azure-policy"
     },
-    "description": "Audits direct Azure RBAC role assignments to individual user identities at subscription or management group scope. Role assignments must be made through Entra ID Groups, Service Principals, or Managed Identities.",
+    "description": "Audits direct Azure RBAC role assignments and PIM active or eligible role schedule requests for individual user identities at subscription or management group scope. Role access must be made through Entra ID Groups, Service Principals, or Managed Identities.",
     "displayName": "HMCTS Restrict Direct User RBAC Assignments",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
-        "message": "Direct user RBAC role assignments at subscription or management group scope are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
+        "message": "Direct user RBAC role assignments, including PIM active or eligible time-bound role assignments, are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
       }
     ],
     "notScopes": [],

--- a/assignments/mgmt-groups/mg-HMCTS/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.rbac_no_direct_user_assignment.json
@@ -3,12 +3,12 @@
     "metadata": {
       "assignedBy": "github.com/hmcts/azure-policy"
     },
-    "description": "Audits direct Azure RBAC role assignments and PIM active or eligible role schedule requests for individual user identities at subscription or management group scope. Role access must be made through Entra ID Groups, Service Principals, or Managed Identities.",
+    "description": "Audits direct Azure RBAC role assignments to individual user identities and time-bound PIM eligible assignments for configured privileged administrator roles at subscription or management group scope.",
     "displayName": "HMCTS Restrict Direct User RBAC Assignments",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
-        "message": "Direct user RBAC role assignments, including PIM active or eligible time-bound role assignments, are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
+        "message": "Direct user RBAC role assignments are not permitted. Time-bound PIM eligible assignments for restricted privileged administrator roles are also not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
       }
     ],
     "notScopes": [],

--- a/assignments/mgmt-groups/mg-HMCTS/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.rbac_no_direct_user_assignment.json
@@ -1,0 +1,30 @@
+{
+  "properties": {
+    "metadata": {
+      "assignedBy": "github.com/hmcts/azure-policy"
+    },
+    "description": "Audits direct Azure RBAC role assignments to individual user identities at subscription or management group scope. Role assignments must be made through Entra ID Groups, Service Principals, or Managed Identities.",
+    "displayName": "HMCTS Restrict Direct User RBAC Assignments",
+    "enforcementMode": "Default",
+    "nonComplianceMessages": [
+      {
+        "message": "Direct user RBAC role assignments at subscription or management group scope are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
+      }
+    ],
+    "notScopes": [],
+    "parameters": {
+      "effect": {
+        "value": "Deny"
+      }
+    },
+    "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSNoDirectUserRbac",
+    "scope": "/providers/Microsoft.Management/managementGroups/HMCTS"
+  },
+  "sku": {
+    "name": "A0",
+    "tier": "Free"
+  },
+  "type": "Microsoft.Authorization/policyAssignments",
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/HMCTSNoDirectUserRbac",
+  "name": "HMCTSNoDirectUserRbac"
+}

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.rbac_no_direct_user_assignment.json
@@ -3,12 +3,12 @@
     "metadata": {
       "assignedBy": "github.com/hmcts/azure-policy"
     },
-    "description": "Audits direct Azure RBAC role assignments and PIM active or eligible role schedule requests for individual user identities at subscription or management group scope. Role access must be made through Entra ID Groups, Service Principals, or Managed Identities.",
+    "description": "Audits direct Azure RBAC role assignments to individual user identities and time-bound PIM eligible assignments for configured privileged administrator roles at subscription or management group scope.",
     "displayName": "HMCTS Restrict Direct User RBAC Assignments - (mg:CFT-Sandbox)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
-        "message": "Direct user RBAC role assignments, including PIM active or eligible time-bound role assignments, are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
+        "message": "Direct user RBAC role assignments are not permitted. Time-bound PIM eligible assignments for restricted privileged administrator roles are also not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
       }
     ],
     "notScopes": [],

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.rbac_no_direct_user_assignment.json
@@ -1,0 +1,26 @@
+{
+  "properties": {
+    "metadata": {
+      "assignedBy": "github.com/hmcts/azure-policy"
+    },
+    "description": "Audits direct Azure RBAC role assignments to individual user identities at subscription or management group scope. Role assignments must be made through Entra ID Groups, Service Principals, or Managed Identities.",
+    "displayName": "HMCTS Restrict Direct User RBAC Assignments - (mg:CFT-Sandbox)",
+    "enforcementMode": "Default",
+    "nonComplianceMessages": [
+      {
+        "message": "Direct user RBAC role assignments at subscription or management group scope are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
+      }
+    ],
+    "notScopes": [],
+    "parameters": {
+      "effect": {
+        "value": "Deny"
+      }
+    },
+    "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSNoDirectUserRbac",
+    "scope": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox"
+  },
+  "type": "Microsoft.Authorization/policyAssignments",
+  "id": "/providers/Microsoft.Management/managementGroups/CFT-Sandbox/providers/Microsoft.Authorization/policyAssignments/HMCTSNoDirectUserRbac-Sbox",
+  "name": "HMCTSNoDirectUserRbac-Sbox"
+}

--- a/assignments/mgmt-groups/mg-cft-sandbox/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/mgmt-groups/mg-cft-sandbox/assign.rbac_no_direct_user_assignment.json
@@ -3,12 +3,12 @@
     "metadata": {
       "assignedBy": "github.com/hmcts/azure-policy"
     },
-    "description": "Audits direct Azure RBAC role assignments to individual user identities at subscription or management group scope. Role assignments must be made through Entra ID Groups, Service Principals, or Managed Identities.",
+    "description": "Audits direct Azure RBAC role assignments and PIM active or eligible role schedule requests for individual user identities at subscription or management group scope. Role access must be made through Entra ID Groups, Service Principals, or Managed Identities.",
     "displayName": "HMCTS Restrict Direct User RBAC Assignments - (mg:CFT-Sandbox)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
-        "message": "Direct user RBAC role assignments at subscription or management group scope are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
+        "message": "Direct user RBAC role assignments, including PIM active or eligible time-bound role assignments, are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
       }
     ],
     "notScopes": [],

--- a/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.rbac_no_direct_user_assignment.json
@@ -3,12 +3,12 @@
     "metadata": {
       "assignedBy": "github.com/hmcts/azure-policy"
     },
-    "description": "Audits direct Azure RBAC role assignments and PIM active or eligible role schedule requests for individual user identities at subscription or management group scope. Role access must be made through Entra ID Groups, Service Principals, or Managed Identities.",
+    "description": "Audits direct Azure RBAC role assignments to individual user identities and time-bound PIM eligible assignments for configured privileged administrator roles at subscription or management group scope.",
     "displayName": "HMCTS Restrict Direct User RBAC Assignments - CFT SBOX (DCD-CFTAPPS-SBOX)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
-        "message": "Direct user RBAC role assignments, including PIM active or eligible time-bound role assignments, are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
+        "message": "Direct user RBAC role assignments are not permitted. Time-bound PIM eligible assignments for restricted privileged administrator roles are also not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
       }
     ],
     "notScopes": [],

--- a/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.rbac_no_direct_user_assignment.json
@@ -3,12 +3,12 @@
     "metadata": {
       "assignedBy": "github.com/hmcts/azure-policy"
     },
-    "description": "Audits direct Azure RBAC role assignments to individual user identities at subscription or management group scope. Role assignments must be made through Entra ID Groups, Service Principals, or Managed Identities.",
+    "description": "Audits direct Azure RBAC role assignments and PIM active or eligible role schedule requests for individual user identities at subscription or management group scope. Role access must be made through Entra ID Groups, Service Principals, or Managed Identities.",
     "displayName": "HMCTS Restrict Direct User RBAC Assignments - CFT SBOX (DCD-CFTAPPS-SBOX)",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
-        "message": "Direct user RBAC role assignments at subscription or management group scope are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
+        "message": "Direct user RBAC role assignments, including PIM active or eligible time-bound role assignments, are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
       }
     ],
     "notScopes": [],

--- a/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.rbac_no_direct_user_assignment.json
@@ -1,0 +1,26 @@
+{
+  "properties": {
+    "metadata": {
+      "assignedBy": "github.com/hmcts/azure-policy"
+    },
+    "description": "Audits direct Azure RBAC role assignments to individual user identities at subscription or management group scope. Role assignments must be made through Entra ID Groups, Service Principals, or Managed Identities.",
+    "displayName": "HMCTS Restrict Direct User RBAC Assignments - CFT SBOX (DCD-CFTAPPS-SBOX)",
+    "enforcementMode": "Default",
+    "nonComplianceMessages": [
+      {
+        "message": "Direct user RBAC role assignments at subscription or management group scope are not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
+      }
+    ],
+    "notScopes": [],
+    "parameters": {
+      "effect": {
+        "value": "Deny"
+      }
+    },
+    "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSNoDirectUserRbac",
+    "scope": "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb"
+  },
+  "type": "Microsoft.Authorization/policyAssignments",
+  "id": "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/providers/Microsoft.Authorization/policyAssignments/HMCTSNoDirectUserRbac-Sbox",
+  "name": "HMCTSNoDirectUserRbac-Sbox"
+}

--- a/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.rbac_no_direct_user_assignment.json
+++ b/assignments/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/assign.rbac_no_direct_user_assignment.json
@@ -11,7 +11,9 @@
         "message": "Direct user RBAC role assignments are not permitted. Time-bound PIM eligible assignments for restricted privileged administrator roles are also not permitted. Assign roles through Entra ID Groups, Service Principals, or Managed Identities. See https://github.com/hmcts/azure-policy/blob/master/policies/rbac_no_direct_user_assignment/README.md"
       }
     ],
-    "notScopes": [],
+    "notScopes": [
+      "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/cft-neuvector-sbox-rg/providers/Microsoft.KeyVault/vaults/cftneuvector-sbox"
+    ],
     "parameters": {
       "effect": {
         "value": "Deny"

--- a/policies/rbac_no_direct_user_assignment/README.md
+++ b/policies/rbac_no_direct_user_assignment/README.md
@@ -1,0 +1,27 @@
+# HMCTS Restrict Direct User RBAC Assignments
+
+This policy denies direct Azure RBAC role access for individual user identities. Access must be granted through Microsoft Entra ID Groups, Service Principals, or Managed Identities.
+
+The policy covers:
+
+- Permanent Azure RBAC role assignments using `Microsoft.Authorization/roleAssignments`.
+- PIM eligible role schedule requests using `Microsoft.Authorization/roleEligibilityScheduleRequests`.
+- PIM active role schedule requests using `Microsoft.Authorization/roleAssignmentScheduleRequests`.
+
+For PIM schedule requests, the policy denies direct user requests that create, update, extend, renew, or activate direct role access. Removal and deactivation request types are not denied so existing direct user access can still be cleaned up.
+
+## Denied principal type
+
+The policy denies requests where the relevant `principalType` is `User`.
+
+## Allowed assignment routes
+
+Use one of the following principal types instead:
+
+- Microsoft Entra ID Groups
+- Service Principals
+- Managed Identities
+
+## Effect
+
+The `effect` parameter supports `Audit`, `Deny`, and `Disabled`.

--- a/policies/rbac_no_direct_user_assignment/README.md
+++ b/policies/rbac_no_direct_user_assignment/README.md
@@ -1,22 +1,46 @@
 # HMCTS Restrict Direct User RBAC Assignments
 
-This policy denies direct Azure RBAC role access for individual user identities. Access must be granted through Microsoft Entra ID Groups, Service Principals, or Managed Identities.
+This policy covers two separate denial conditions:
 
-The policy covers:
+1. **Permanent direct user RBAC assignments** — denies any `Microsoft.Authorization/roleAssignments` where `principalType` is `User`. All users are blocked; access must be granted through Entra ID Groups, Service Principals, or Managed Identities.
 
-- Permanent Azure RBAC role assignments using `Microsoft.Authorization/roleAssignments`.
-- PIM eligible role schedule requests using `Microsoft.Authorization/roleEligibilityScheduleRequests`.
-- PIM active role schedule requests using `Microsoft.Authorization/roleAssignmentScheduleRequests`.
+2. **Time-bound PIM eligible assignments for privileged administrator roles** — denies `Microsoft.Authorization/roleEligibilityScheduleRequests` where the requested role is in the configured list of privileged role definition IDs and the schedule includes a time-bound expiration (`AfterDateTime` or `AfterDuration`). This applies regardless of whether the principal is a user or group.
 
-For PIM schedule requests, the policy denies direct user requests that create, update, extend, renew, or activate direct role access. Removal and deactivation request types are not denied so existing direct user access can still be cleaned up.
+## Why two separate conditions?
 
-## Denied principal type
+PIM eligibility requests are a distinct ARM resource type from permanent role assignments. The portal creates eligibility requests without including `principalType` in the write payload, so the policy targets the privileged **role definition ID** and **expiration type** instead, which are reliably present at request time.
 
-The policy denies requests where the relevant `principalType` is `User`.
+## Privileged roles covered by the PIM condition
+
+The default `privilegedEligibleRoleDefinitionIds` parameter includes the following roles:
+
+| Role | GUID | Type |
+|---|---|---|
+| Owner | `8e3af657-a8ff-443c-a75c-2fe8c4bcb635` | BuiltIn |
+| Contributor | `b24988ac-6180-42a0-ab88-20f7382dd24c` | BuiltIn |
+| Access Review Operator Service Role | `76cc9ee4-d5d3-4a45-a930-26add3d73475` | BuiltIn |
+| AKS_Managed_Identity_IAM_permission | `47f63fd2-88d0-4e8b-a9d3-ec1b22dbcda8` | Custom |
+| Anyscale Platform Administrator Role | `3e9f3756-203e-4734-a0b8-4b68691ffae3` | BuiltIn |
+| Azure Contributor Role minus deletes | `1b0ab888-75d4-8745-1775-d28ca6f274bd` | Custom |
+| PIM Azure Contributor | `3708454d-4324-72bf-2d6b-e12fabe44e76` | Custom |
+| Reservations Administrator | `a8889054-8d42-49c9-bc1c-52486c10e7cd` | BuiltIn |
+| Role Assigner | `46353517-4294-41a8-9fb7-b59022f438db` | Custom |
+| Role Based Access Control Administrator | `f58310d9-a9f6-439a-9e8d-f62e7b41a168` | BuiltIn |
+| Service Group Administrator | `4e50c84c-c78e-4e37-b47e-e60ffea0a775` | BuiltIn |
+| Service Group Contributor | `32e6a4ec-6095-4e37-b54b-12aa350ba81f` | BuiltIn |
+| User Access Administrator | `18d7d88d-d35e-4fb5-a5c3-7773c20a72d9` | BuiltIn |
+
+To add or remove roles, override the `privilegedEligibleRoleDefinitionIds` parameter in the relevant assignment file with the updated list of role GUIDs.
+
+## What is not blocked
+
+- Time-bound PIM eligible assignments for **non-privileged roles** are allowed. The expiration restriction only applies to the roles listed in the privileged role table above.
+- PIM eligible assignments with no expiry (`NoExpiration`) for privileged roles are allowed.
+
 
 ## Allowed assignment routes
 
-Use one of the following principal types instead:
+For permanent access, use one of the following principal types:
 
 - Microsoft Entra ID Groups
 - Service Principals
@@ -24,4 +48,4 @@ Use one of the following principal types instead:
 
 ## Effect
 
-The `effect` parameter supports `Audit`, `Deny`, and `Disabled`.
+The `effect` parameter supports `Audit`, `Deny`, and `Disabled`. Assignments currently set this to `Deny`.

--- a/policies/rbac_no_direct_user_assignment/policy.json
+++ b/policies/rbac_no_direct_user_assignment/policy.json
@@ -1,9 +1,9 @@
 {
   "properties": {
-    "displayName": "HMCTS Restrict Direct User RBAC Assignments",
+    "displayName": "HMCTS Restrict Direct User RBAC Assignments at Subscription and Management Group Scope",
     "policyType": "Custom",
     "mode": "All",
-    "description": "Denies direct Azure RBAC role assignments and PIM active or eligible role schedule requests for individual user identities at any scope. Role access must be granted through Microsoft Entra ID Groups, Service Principals, or Managed Identities to enforce governed access pathways and reduce standing privilege risk.",
+    "description": "Audits or denies direct Azure RBAC role assignments to individual user identities at any scope, and time-bound PIM eligible assignments for configured privileged administrator roles. Role assignments must be made through Microsoft Entra ID Groups, Service Principals, or Managed Identities to enforce governed access pathways and reduce standing privilege risk.",
     "metadata": {
       "category": "Authorization"
     },
@@ -12,7 +12,7 @@
         "type": "String",
         "metadata": {
           "displayName": "Effect",
-          "description": "Audit logs non-compliant assignments. Deny prevents new direct user assignments and PIM schedule requests. Disabled turns off the policy."
+          "description": "Audit logs non-compliant assignments. Deny prevents new direct user assignments and configured privileged eligible assignments. Disabled turns off the policy."
         },
         "allowedValues": [
           "Audit",
@@ -20,6 +20,28 @@
           "Disabled"
         ],
         "defaultValue": "Audit"
+      },
+      "privilegedEligibleRoleDefinitionIds": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Privileged eligible role definition IDs",
+          "description": "Role definition GUIDs for privileged administrator roles where time-bound PIM eligible assignments should be denied."
+        },
+        "defaultValue": [
+          "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+          "b24988ac-6180-42a0-ab88-20f7382dd24c",
+          "76cc9ee4-d5d3-4a45-a930-26add3d73475",
+          "47f63fd2-88d0-4e8b-a9d3-ec1b22dbcda8",
+          "3e9f3756-203e-4734-a0b8-4b68691ffae3",
+          "1b0ab888-75d4-8745-1775-d28ca6f274bd",
+          "3708454d-4324-72bf-2d6b-e12fabe44e76",
+          "a8889054-8d42-49c9-bc1c-52486c10e7cd",
+          "46353517-4294-41a8-9fb7-b59022f438db",
+          "f58310d9-a9f6-439a-9e8d-f62e7b41a168",
+          "4e50c84c-c78e-4e37-b47e-e60ffea0a775",
+          "32e6a4ec-6095-4e37-b54b-12aa350ba81f",
+          "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
+        ]
       }
     },
     "policyRule": {
@@ -44,18 +66,6 @@
                 "equals": "Microsoft.Authorization/roleEligibilityScheduleRequests"
               },
               {
-                "anyOf": [
-                  {
-                    "field": "Microsoft.Authorization/roleEligibilityScheduleRequests/principalType",
-                    "equals": "User"
-                  },
-                  {
-                    "field": "Microsoft.Authorization/roleEligibilityScheduleRequests/expandedProperties.principal.type",
-                    "equals": "User"
-                  }
-                ]
-              },
-              {
                 "field": "Microsoft.Authorization/roleEligibilityScheduleRequests/requestType",
                 "in": [
                   "AdminAssign",
@@ -63,38 +73,17 @@
                   "AdminExtend",
                   "AdminRenew"
                 ]
-              }
-            ]
-          },
-          {
-            "allOf": [
-              {
-                "field": "type",
-                "equals": "Microsoft.Authorization/roleAssignmentScheduleRequests"
               },
               {
-                "anyOf": [
-                  {
-                    "field": "Microsoft.Authorization/roleAssignmentScheduleRequests/principalType",
-                    "equals": "User"
-                  },
-                  {
-                    "field": "Microsoft.Authorization/roleAssignmentScheduleRequests/expandedProperties.principal.type",
-                    "equals": "User"
-                  }
-                ]
-              },
-              {
-                "field": "Microsoft.Authorization/roleAssignmentScheduleRequests/requestType",
+                "field": "Microsoft.Authorization/roleEligibilityScheduleRequests/scheduleInfo.expiration.type",
                 "in": [
-                  "AdminAssign",
-                  "AdminUpdate",
-                  "AdminExtend",
-                  "AdminRenew",
-                  "SelfActivate",
-                  "SelfExtend",
-                  "SelfRenew"
+                  "AfterDateTime",
+                  "AfterDuration"
                 ]
+              },
+              {
+                "value": "[last(split(field('Microsoft.Authorization/roleEligibilityScheduleRequests/roleDefinitionId'), '/'))]",
+                "in": "[parameters('privilegedEligibleRoleDefinitionIds')]"
               }
             ]
           }

--- a/policies/rbac_no_direct_user_assignment/policy.json
+++ b/policies/rbac_no_direct_user_assignment/policy.json
@@ -1,0 +1,46 @@
+{
+  "properties": {
+    "displayName": "HMCTS Restrict Direct User RBAC Assignments at Subscription and Management Group Scope",
+    "policyType": "Custom",
+    "mode": "All",
+    "description": "Audits or denies direct Azure RBAC role assignments to individual user identities at any scope (management group, subscription, resource group, or resource). Role assignments must be made through Microsoft Entra ID Groups, Service Principals, or Managed Identities to enforce governed access pathways and reduce standing privilege risk.",
+    "metadata": {
+      "category": "Authorization"
+    },
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Audit logs non-compliant assignments. Deny prevents new direct user assignments. Disabled turns off the policy."
+        },
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Authorization/roleAssignments"
+          },
+          {
+            "field": "Microsoft.Authorization/roleAssignments/principalType",
+            "equals": "User"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  },
+  "id": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSNoDirectUserRbac",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "name": "HMCTSNoDirectUserRbac"
+}

--- a/policies/rbac_no_direct_user_assignment/policy.json
+++ b/policies/rbac_no_direct_user_assignment/policy.json
@@ -3,7 +3,7 @@
     "displayName": "HMCTS Restrict Direct User RBAC Assignments",
     "policyType": "Custom",
     "mode": "All",
-    "description": "Audits or denies direct Azure RBAC role assignments (both permanent active and PIM eligible) to individual user identities at any scope. Role assignments must be made through Microsoft Entra ID Groups, Service Principals, or Managed Identities to enforce governed access pathways and reduce standing privilege risk.",
+    "description": "Denies direct Azure RBAC role assignments and PIM active or eligible role schedule requests for individual user identities at any scope. Role access must be granted through Microsoft Entra ID Groups, Service Principals, or Managed Identities to enforce governed access pathways and reduce standing privilege risk.",
     "metadata": {
       "category": "Authorization"
     },
@@ -12,7 +12,7 @@
         "type": "String",
         "metadata": {
           "displayName": "Effect",
-          "description": "Audit logs non-compliant assignments. Deny prevents new direct user assignments. Disabled turns off the policy."
+          "description": "Audit logs non-compliant assignments. Deny prevents new direct user assignments and PIM schedule requests. Disabled turns off the policy."
         },
         "allowedValues": [
           "Audit",
@@ -44,8 +44,57 @@
                 "equals": "Microsoft.Authorization/roleEligibilityScheduleRequests"
               },
               {
-                "field": "Microsoft.Authorization/roleEligibilityScheduleRequests/principalType",
-                "equals": "User"
+                "anyOf": [
+                  {
+                    "field": "Microsoft.Authorization/roleEligibilityScheduleRequests/principalType",
+                    "equals": "User"
+                  },
+                  {
+                    "field": "Microsoft.Authorization/roleEligibilityScheduleRequests/expandedProperties.principal.type",
+                    "equals": "User"
+                  }
+                ]
+              },
+              {
+                "field": "Microsoft.Authorization/roleEligibilityScheduleRequests/requestType",
+                "in": [
+                  "AdminAssign",
+                  "AdminUpdate",
+                  "AdminExtend",
+                  "AdminRenew"
+                ]
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.Authorization/roleAssignmentScheduleRequests"
+              },
+              {
+                "anyOf": [
+                  {
+                    "field": "Microsoft.Authorization/roleAssignmentScheduleRequests/principalType",
+                    "equals": "User"
+                  },
+                  {
+                    "field": "Microsoft.Authorization/roleAssignmentScheduleRequests/expandedProperties.principal.type",
+                    "equals": "User"
+                  }
+                ]
+              },
+              {
+                "field": "Microsoft.Authorization/roleAssignmentScheduleRequests/requestType",
+                "in": [
+                  "AdminAssign",
+                  "AdminUpdate",
+                  "AdminExtend",
+                  "AdminRenew",
+                  "SelfActivate",
+                  "SelfExtend",
+                  "SelfRenew"
+                ]
               }
             ]
           }

--- a/policies/rbac_no_direct_user_assignment/policy.json
+++ b/policies/rbac_no_direct_user_assignment/policy.json
@@ -1,9 +1,9 @@
 {
   "properties": {
-    "displayName": "HMCTS Restrict Direct User RBAC Assignments at Subscription and Management Group Scope",
+    "displayName": "HMCTS Restrict Direct User RBAC Assignments",
     "policyType": "Custom",
     "mode": "All",
-    "description": "Audits or denies direct Azure RBAC role assignments to individual user identities at any scope (management group, subscription, resource group, or resource). Role assignments must be made through Microsoft Entra ID Groups, Service Principals, or Managed Identities to enforce governed access pathways and reduce standing privilege risk.",
+    "description": "Audits or denies direct Azure RBAC role assignments (both permanent active and PIM eligible) to individual user identities at any scope. Role assignments must be made through Microsoft Entra ID Groups, Service Principals, or Managed Identities to enforce governed access pathways and reduce standing privilege risk.",
     "metadata": {
       "category": "Authorization"
     },
@@ -24,14 +24,30 @@
     },
     "policyRule": {
       "if": {
-        "allOf": [
+        "anyOf": [
           {
-            "field": "type",
-            "equals": "Microsoft.Authorization/roleAssignments"
+            "allOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.Authorization/roleAssignments"
+              },
+              {
+                "field": "Microsoft.Authorization/roleAssignments/principalType",
+                "equals": "User"
+              }
+            ]
           },
           {
-            "field": "Microsoft.Authorization/roleAssignments/principalType",
-            "equals": "User"
+            "allOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.Authorization/roleEligibilityScheduleRequests"
+              },
+              {
+                "field": "Microsoft.Authorization/roleEligibilityScheduleRequests/principalType",
+                "equals": "User"
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
### Jira link

See [DTSPO-32627](https://tools.hmcts.net/jira/browse/DTSPO-32627)

### Change description

Adds a new custom Azure Policy (`HMCTSNoDirectUserRbac`) that denies direct RBAC role assignments to individual user identities at any scope (management group, subscription, resource group, or resource level).

Role assignments to Microsoft Entra ID Groups, Service Principals, and Managed Identities remain fully permitted.

Files added:
- `policies/rbac_no_direct_user_assignment/policy.json` — policy definition with Audit/Deny/Disabled effect parameter, assigned with Deny
- `assignments/mgmt-groups/mg-cft-sandbox/` — test assignment scoped to CFT-Sandbox MG
- `assignments/subscriptions/b72ab7b7.../` — test assignment scoped to DCD-CFTAPPS-SBOX
- `assignments/mgmt-groups/mg-HMCTS/` — production assignment scoped to HMCTS MG

Policy rule: deny any roleAssignment where principalType == User.

Why: Direct user assignments create inconsistency, weaken auditability, and undermine least-privilege controls. This aligns with the Access Package-backed governance model (Epic DTSPO-29812).

### Testing done

PR GitHub Action will deploy sandbox assignments to CFT-Sandbox MG and DCD-CFTAPPS-SBOX. Verify that direct-user assignments surface as non-compliant and that Group/SP/MSI assignments remain compliant. Add notScopes exemptions before merging if any breakglass identities need a transition window.

### Security Vulnerability Assessment ###

**CVE Suppression:** No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change