### PR TITLE
ADOP-2789: Adding location policy exclusions

### DIFF
--- a/assignments/mgmt-groups/mg-HMCTS/assign.allowed_regions.json
+++ b/assignments/mgmt-groups/mg-HMCTS/assign.allowed_regions.json
@@ -153,7 +153,12 @@
         "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/nfdiv-ithc",
         "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/nfdiv-perftest",
         "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/nfdiv-prod",
-        "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/platops-tiger-team-poc-rg"
+        "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/platops-tiger-team-poc-rg",
+        "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/adoption-aat",
+        "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/adoption-demo",
+        "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/adoption-ithc",
+        "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/adoption-perftest",
+        "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/adoption-prod"
       ],
       "parameters": {},
       "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyDefinitions/HMCTSResourceLocationPolicy",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ADOP-2789

Added location policy exclusions for adoption application insights instances

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [] Does this PR introduce a breaking change
